### PR TITLE
Prevent "DZ" from being decoded to an unicode character.

### DIFF
--- a/latexcodec/codec.py
+++ b/latexcodec/codec.py
@@ -388,7 +388,7 @@ class LatexUnicodeTable:
         self.register(u'\N{LATIN CAPITAL LETTER O WITH OGONEK}', b'\\c O')
         self.register(u'\N{LATIN SMALL LETTER O WITH OGONEK}', b'\\c o')
         self.register(u'\N{LATIN SMALL LETTER J WITH CARON}', b'\\v\\j')
-        self.register(u'\N{LATIN CAPITAL LETTER DZ}', b'DZ')
+        self.register(u'\N{LATIN CAPITAL LETTER DZ}', b'DZ', decode=False)
         self.register(
             u'\N{LATIN CAPITAL LETTER D WITH SMALL LETTER Z}',
             b'Dz',


### PR DESCRIPTION
Thanks for the wonderful and simple-to-use package! I use it for "cleaning" .bib files when converting it to other bibliographic formats. The only problem I had was that "DZ" that was sometimes used as the abbreviations of the first and middle name was converted in an Unicode character. This small patch solved my problem: Now DZ is treated like other double ASCII characters like e.g. NJ where the parameter "decode" is False as well:

``` python
self.register(u'\N{LATIN CAPITAL LETTER NJ}', b'NJ', decode=False)
```
