### PR TITLE
add "DOUBLE LOW-9 QUOTATION MARK" (in latex \glqq) to the register_al…

### DIFF
--- a/latexcodec/codec.py
+++ b/latexcodec/codec.py
@@ -111,6 +111,7 @@ class LatexUnicodeTable:
         self.register(u'\N{RIGHT SINGLE QUOTATION MARK}', b"'", decode=False)
         self.register(u'\N{LEFT DOUBLE QUOTATION MARK}', b'``')
         self.register(u'\N{RIGHT DOUBLE QUOTATION MARK}', b"''")
+        self.register(u'\N{DOUBLE LOW-9 QUOTATION MARK}', b'\\glqq')
         self.register(u'\N{DAGGER}', b'\\dag')
         self.register(u'\N{DOUBLE DAGGER}', b'\\ddag')
 


### PR DESCRIPTION
The  double low quotation mark is used in German and therefore I add it to the register_all function 