### PR TITLE
Support decoding math in backslash braces

### DIFF
--- a/latexcodec/codec.py
+++ b/latexcodec/codec.py
@@ -569,6 +569,9 @@ class LatexUnicodeTable:
             # also register text version
             self.register(unicode_text, b'$' + latex_text + b'$', mode='text',
                           package=package, decode=decode, encode=encode)
+            self.register(unicode_text,
+                          br'\(' + latex_text + br'\)', mode='text',
+                          package=package, decode=decode, encode=encode)
             # XXX for the time being, we do not perform in-math substitutions
             return
         if not self.lexer.binary_mode:

--- a/test/test_latex_codec.py
+++ b/test/test_latex_codec.py
@@ -179,8 +179,11 @@ class TestDecoder(TestCase):
         self.decode(u"\\textogonekcentered {Ō}\\textogonekcentered {ō}",
                     br'\textogonekcentered{\=O}\textogonekcentered{\=o}')
 
-    def test_math_spacing(self):
+    def test_math_spacing_dollar(self):
         self.decode(u'This is a ψ test.', br'This is a $\psi$ test.')
+
+    def test_math_spacing_brace(self):
+        self.decode(u'This is a ψ test.', br'This is a \(\psi\) test.')
 
     def test_double_math(self):
         # currently no attempt to translate maths inside $$


### PR DESCRIPTION
Contents within `\(` and `\)` should also be seen as math.

Also see [this](https://tex.stackexchange.com/questions/510/are-and-preferable-to-dollar-signs-for-math-mode).