### PR TITLE
Add a new encode error type "skip" for ulatex to skip unknown chars.

### DIFF
--- a/latexcodec/codec.py
+++ b/latexcodec/codec.py
@@ -693,10 +693,12 @@ class LatexIncrementalEncoder(lexer.LatexIncrementalEncoder):
                 else:
                     bytes_ = u'{\\char' + str(ord(c)) + u'}'
                 return bytes_, (lexer.Token(name='chars', text=bytes_),)
+            elif self.errors == 'skip' and not self.binary_mode:
+                return c,  (lexer.Token(name='chars', text=c),)
             else:
                 raise ValueError(
-                    "latex codec does not support {0} errors"
-                    .format(self.errors))
+                    "{1}latex codec does not support {0} errors"
+                    .format(self.errors, '' if self.binary_mode else 'u'))
 
     def get_latex_bytes(self, unicode_, final=False):
         if not isinstance(unicode_, string_types):

--- a/test/test_latex_codec.py
+++ b/test/test_latex_codec.py
@@ -259,6 +259,11 @@ class TestEncoder(TestCase):
     def test_invalid_code_replace(self):
         self.encode(u'\u2328', b'{\\char9000}', 'ascii', 'replace')
 
+    def test_invalid_code_skip(self):
+        import codecs
+        self.assertEqual(
+            codecs.encode(u'\u2328', 'ulatex', 'skip'), u'\u2328')
+
     @nose.tools.raises(ValueError)
     def test_invalid_code_baderror(self):
         self.encode(u'\u2328', b'', 'ascii', '**baderror**')


### PR DESCRIPTION
Also, we need to add these to the documentation.