### PR TITLE
Allow ulatex codec to keep characters when encoding fails.

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -46,6 +46,26 @@ The following code snippet demonstrates this behaviour:
     assert text_unicode.encode("latex+latin1") == b'\\c t'  # ţ is not latin1
     assert text_unicode.encode("latex+latin2") == b'\xfe'   # but it is latin2
 
+When encoding using the ``ulatex`` codec, you have the option to pass
+through characters that cannot be encoded in the desired encoding, by
+using the ``'keep'`` error. This can be a useful fallback option if
+you want to encode as much as possible, whilst still retaining as much
+as possible of the original code when encoding fails. If instead you
+want to translate to LaTeX but keep as much of the unicode as
+possible, use the ``ulatex+utf8`` codec, which should never fail.
+
+.. code-block::
+
+    import latexcodec
+    text_unicode = u'⌨'  # \u2328 = keyboard symbol, currently not translated
+    try:
+        # raises a value error as \u2328 cannot be encoded into latex
+        text_unicode.encode("ulatex+ascii")
+    except ValueError:
+        pass
+    assert text_unicode.encode("ulatex+ascii", errors="keep") == u'⌨'
+    assert text_unicode.encode("ulatex+utf8") == u'⌨'
+
 Limitations
 -----------
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -56,15 +56,16 @@ possible, use the ``ulatex+utf8`` codec, which should never fail.
 
 .. code-block::
 
+    import codecs
     import latexcodec
     text_unicode = u'⌨'  # \u2328 = keyboard symbol, currently not translated
     try:
         # raises a value error as \u2328 cannot be encoded into latex
-        text_unicode.encode("ulatex+ascii")
+        codecs.encode(text_unicode, "ulatex+ascii")
     except ValueError:
         pass
-    assert text_unicode.encode("ulatex+ascii", errors="keep") == u'⌨'
-    assert text_unicode.encode("ulatex+utf8") == u'⌨'
+    assert codecs.encode(text_unicode, "ulatex+ascii", "keep") == u'⌨'
+    assert codecs.encode(text_unicode, "ulatex+utf8") == u'⌨'
 
 Limitations
 -----------

--- a/latexcodec/codec.py
+++ b/latexcodec/codec.py
@@ -693,6 +693,8 @@ class LatexIncrementalEncoder(lexer.LatexIncrementalEncoder):
                 else:
                     bytes_ = u'{\\char' + str(ord(c)) + u'}'
                 return bytes_, (lexer.Token(name='chars', text=bytes_),)
+            elif self.errors == 'keep' and not self.binary_mode:
+                return c,  (lexer.Token(name='chars', text=c),)
             else:
                 raise ValueError(
                     "latex codec does not support {0} errors"

--- a/test/test_install_example.py
+++ b/test/test_install_example.py
@@ -26,3 +26,15 @@ def test_install_example_3():
     text_unicode = u"ţ"
     assert text_unicode.encode("latex+latin1") == b'\\c t'  # ţ is not latin1
     assert text_unicode.encode("latex+latin2") == b'\xfe'   # but it is latin2
+
+
+def test_install_example_4():
+    import latexcodec  # noqa
+    text_unicode = u'⌨'  # \u2328 = keyboard symbol, currently not translated
+    try:
+        # raises a value error as \u2328 cannot be encoded into latex
+        text_unicode.encode("ulatex+ascii")
+    except ValueError:
+        pass
+    assert text_unicode.encode("ulatex+ascii", errors="keep") == u'⌨'
+    assert text_unicode.encode("ulatex+utf8") == u'⌨'

--- a/test/test_install_example.py
+++ b/test/test_install_example.py
@@ -29,12 +29,13 @@ def test_install_example_3():
 
 
 def test_install_example_4():
+    import codecs
     import latexcodec  # noqa
     text_unicode = u'⌨'  # \u2328 = keyboard symbol, currently not translated
     try:
         # raises a value error as \u2328 cannot be encoded into latex
-        text_unicode.encode("ulatex+ascii")
+        codecs.encode(text_unicode, "ulatex+ascii")
     except ValueError:
         pass
-    assert text_unicode.encode("ulatex+ascii", errors="keep") == u'⌨'
-    assert text_unicode.encode("ulatex+utf8") == u'⌨'
+    assert codecs.encode(text_unicode, "ulatex+ascii", "keep") == u'⌨'
+    assert codecs.encode(text_unicode, "ulatex+utf8") == u'⌨'

--- a/test/test_latex_codec.py
+++ b/test/test_latex_codec.py
@@ -423,9 +423,15 @@ class TestUnicodeEncoder(TestEncoder):
     def test_ulatex_utf8(self):
         self.uencode(u'# ψ', u'\# ψ', 'utf8')
 
+    # the following tests rely on the fact that \u2328 is not in our
+    # translation table
+
     @nose.tools.raises(ValueError)
     def test_ulatex_ascii_invalid(self):
         self.uencode(u'# \u2328', u'', 'ascii')
 
     def test_ulatex_utf8_invalid(self):
-        self.uencode(u'# \u2328', u'\# \u2328', 'utf8')
+        self.uencode(u'# ψ \u2328', u'\# ψ \u2328', 'utf8')
+
+    def test_invalid_code_keep(self):
+        self.uencode(u'# ψ \u2328', u'\# $\psi$ \u2328', 'ascii', 'keep')


### PR DESCRIPTION
See pull request #45.

@xuhdev What do you think? I've changed the name to "keep", because "skip" sounds like it will skip invalid characters, which might be confusing.