### PR TITLE
LaTeX lexer reads and writes Unicode strings instead of byte strings

### DIFF
--- a/latexcodec/codec.py
+++ b/latexcodec/codec.py
@@ -61,7 +61,6 @@
 from __future__ import print_function
 
 import codecs
-import six
 from six import string_types, text_type
 from six.moves import range
 
@@ -238,7 +237,7 @@ class LatexUnicodeTable:
         self.register(u'\N{LATIN SMALL LETTER I WITH ACUTE}', u"\\'i")
         self.register(u'\N{LATIN SMALL LETTER I WITH CIRCUMFLEX}', u'\\^\\i')
         self.register(u'\N{LATIN SMALL LETTER I WITH CIRCUMFLEX}', u'\\^i')
-        self.register(u'\N{LATIN SMALL LETTER I WITH DIAERESIS}', u'\\"\\i') 
+        self.register(u'\N{LATIN SMALL LETTER I WITH DIAERESIS}', u'\\"\\i')
         self.register(u'\N{LATIN SMALL LETTER I WITH DIAERESIS}', u'\\"i')
         self.register(u'\N{LATIN SMALL LETTER N WITH TILDE}', u'\\~n')
         self.register(u'\N{LATIN SMALL LETTER O WITH GRAVE}', u'\\`o')
@@ -588,8 +587,10 @@ class LatexUnicodeTable:
             package='textcomp')
         # \=O and \=o will be translated into Ō and ō before we can
         # match the full latex string... so decoding disabled for now
-        self.register(u'Ǭ', text_type(r'\textogonekcentered{\=O}'), decode=False)
-        self.register(u'ǭ', text_type(r'\textogonekcentered{\=o}'), decode=False)
+        self.register(u'Ǭ', text_type(r'\textogonekcentered{\=O}'),
+                      decode=False)
+        self.register(u'ǭ', text_type(r'\textogonekcentered{\=o}'),
+                      decode=False)
         self.register(u'ℕ', text_type(r'\mathbb{N}'), mode='math')
         self.register(u'ℕ', text_type(r'\mathbb N'), mode='math', decode=False)
         self.register(u'ℤ', text_type(r'\mathbb{Z}'), mode='math')
@@ -620,8 +621,9 @@ class LatexUnicodeTable:
             self.register(unicode_text, u'$' + latex_text + u'$', mode='text',
                           package=package, decode=decode, encode=encode)
             self.register(unicode_text,
-                          text_type(r'\(') + latex_text + text_type(r'\)'), mode='text',
-                          package=package, decode=decode, encode=encode)
+                          text_type(r'\(') + latex_text + text_type(r'\)'),
+                          mode='text', package=package,
+                          decode=decode, encode=encode)
             # XXX for the time being, we do not perform in-math substitutions
             return
         if package is not None:

--- a/latexcodec/codec.py
+++ b/latexcodec/codec.py
@@ -61,6 +61,7 @@
 from __future__ import print_function
 
 import codecs
+import six
 from six import string_types
 from six.moves import range
 
@@ -100,512 +101,512 @@ class LatexUnicodeTable:
         """
         # TODO complete this list
         # register special symbols
-        self.register(u'\n\n', b' \\par', encode=False)
-        self.register(u'\n\n', b'\\par', encode=False)
-        self.register(u' ', b'\\ ', encode=False)
-        self.register(u'\N{EM SPACE}', b'\\quad')
-        self.register(u'%', b'\\%')
-        self.register(u'\N{EN DASH}', b'--')
-        self.register(u'\N{EN DASH}', b'\\textendash')
-        self.register(u'\N{EM DASH}', b'---')
-        self.register(u'\N{EM DASH}', b'\\textemdash')
-        self.register(u'\N{LEFT SINGLE QUOTATION MARK}', b'`', decode=False)
-        self.register(u'\N{RIGHT SINGLE QUOTATION MARK}', b"'", decode=False)
-        self.register(u'\N{LEFT DOUBLE QUOTATION MARK}', b'``')
-        self.register(u'\N{RIGHT DOUBLE QUOTATION MARK}', b"''")
-        self.register(u'\N{DOUBLE LOW-9 QUOTATION MARK}', b'\\glqq')
-        self.register(u'\N{DAGGER}', b'\\dag')
-        self.register(u'\N{DOUBLE DAGGER}', b'\\ddag')
+        self.register(u'\n\n', u' \\par', encode=False)
+        self.register(u'\n\n', u'\\par', encode=False)
+        self.register(u' ', u'\\ ', encode=False)
+        self.register(u'\N{EM SPACE}', u'\\quad')
+        self.register(u'%', u'\\%')
+        self.register(u'\N{EN DASH}', u'--')
+        self.register(u'\N{EN DASH}', u'\\textendash')
+        self.register(u'\N{EM DASH}', u'---')
+        self.register(u'\N{EM DASH}', u'\\textemdash')
+        self.register(u'\N{LEFT SINGLE QUOTATION MARK}', u'`', decode=False)
+        self.register(u'\N{RIGHT SINGLE QUOTATION MARK}', u"'", decode=False)
+        self.register(u'\N{LEFT DOUBLE QUOTATION MARK}', u'``')
+        self.register(u'\N{RIGHT DOUBLE QUOTATION MARK}', u"''")
+        self.register(u'\N{DOUBLE LOW-9 QUOTATION MARK}', u'\\glqq')
+        self.register(u'\N{DAGGER}', u'\\dag')
+        self.register(u'\N{DOUBLE DAGGER}', u'\\ddag')
 
-        self.register(u'\\', b'\\textbackslash', encode=False)
-        self.register(u'\\', b'\\backslash', mode='math', encode=False)
+        self.register(u'\\', u'\\textbackslash', encode=False)
+        self.register(u'\\', u'\\backslash', mode='math', encode=False)
 
-        self.register(u'\N{TILDE OPERATOR}', b'\\sim', mode='math')
+        self.register(u'\N{TILDE OPERATOR}', u'\\sim', mode='math')
         self.register(u'\N{MODIFIER LETTER LOW TILDE}',
-                      b'\\texttildelow', package='textcomp')
-        self.register(u'\N{SMALL TILDE}', b'\\~{}')
-        self.register(u'~', b'\\textasciitilde')
+                      u'\\texttildelow', package='textcomp')
+        self.register(u'\N{SMALL TILDE}', u'\\~{}')
+        self.register(u'~', u'\\textasciitilde')
 
-        self.register(u'\N{BULLET}', b'\\bullet', mode='math')
-        self.register(u'\N{BULLET}', b'\\textbullet', package='textcomp')
+        self.register(u'\N{BULLET}', u'\\bullet', mode='math')
+        self.register(u'\N{BULLET}', u'\\textbullet', package='textcomp')
 
-        self.register(u'\N{NUMBER SIGN}', b'\\#')
-        self.register(u'\N{LOW LINE}', b'\\_')
-        self.register(u'\N{AMPERSAND}', b'\\&')
-        self.register(u'\N{NO-BREAK SPACE}', b'~')
-        self.register(u'\N{INVERTED EXCLAMATION MARK}', b'!`')
-        self.register(u'\N{CENT SIGN}', b'\\not{c}')
+        self.register(u'\N{NUMBER SIGN}', u'\\#')
+        self.register(u'\N{LOW LINE}', u'\\_')
+        self.register(u'\N{AMPERSAND}', u'\\&')
+        self.register(u'\N{NO-BREAK SPACE}', u'~')
+        self.register(u'\N{INVERTED EXCLAMATION MARK}', u'!`')
+        self.register(u'\N{CENT SIGN}', u'\\not{c}')
 
-        self.register(u'\N{POUND SIGN}', b'\\pounds')
-        self.register(u'\N{POUND SIGN}', b'\\textsterling', package='textcomp')
+        self.register(u'\N{POUND SIGN}', u'\\pounds')
+        self.register(u'\N{POUND SIGN}', u'\\textsterling', package='textcomp')
 
-        self.register(u'\N{SECTION SIGN}', b'\\S')
-        self.register(u'\N{DIAERESIS}', b'\\"{}')
-        self.register(u'\N{NOT SIGN}', b'\\neg')
-        self.register(u'\N{HYPHEN}', b'-', decode=False)
-        self.register(u'\N{SOFT HYPHEN}', b'\\-')
-        self.register(u'\N{MACRON}', b'\\={}')
+        self.register(u'\N{SECTION SIGN}', u'\\S')
+        self.register(u'\N{DIAERESIS}', u'\\"{}')
+        self.register(u'\N{NOT SIGN}', u'\\neg')
+        self.register(u'\N{HYPHEN}', u'-', decode=False)
+        self.register(u'\N{SOFT HYPHEN}', u'\\-')
+        self.register(u'\N{MACRON}', u'\\={}')
 
-        self.register(u'\N{DEGREE SIGN}', b'^\\circ', mode='math')
-        self.register(u'\N{DEGREE SIGN}', b'\\textdegree', package='textcomp')
+        self.register(u'\N{DEGREE SIGN}', u'^\\circ', mode='math')
+        self.register(u'\N{DEGREE SIGN}', u'\\textdegree', package='textcomp')
 
-        self.register(u'\N{MINUS SIGN}', b'-', mode='math')
-        self.register(u'\N{PLUS-MINUS SIGN}', b'\\pm', mode='math')
-        self.register(u'\N{PLUS-MINUS SIGN}', b'\\textpm', package='textcomp')
+        self.register(u'\N{MINUS SIGN}', u'-', mode='math')
+        self.register(u'\N{PLUS-MINUS SIGN}', u'\\pm', mode='math')
+        self.register(u'\N{PLUS-MINUS SIGN}', u'\\textpm', package='textcomp')
 
-        self.register(u'\N{SUPERSCRIPT TWO}', b'^2', mode='math')
+        self.register(u'\N{SUPERSCRIPT TWO}', u'^2', mode='math')
         self.register(
             u'\N{SUPERSCRIPT TWO}',
-            b'\\texttwosuperior',
+            u'\\texttwosuperior',
             package='textcomp')
 
-        self.register(u'\N{SUPERSCRIPT THREE}', b'^3', mode='math')
+        self.register(u'\N{SUPERSCRIPT THREE}', u'^3', mode='math')
         self.register(
             u'\N{SUPERSCRIPT THREE}',
-            b'\\textthreesuperior',
+            u'\\textthreesuperior',
             package='textcomp')
 
-        self.register(u'\N{ACUTE ACCENT}', b"\\'{}")
+        self.register(u'\N{ACUTE ACCENT}', u"\\'{}")
 
-        self.register(u'\N{MICRO SIGN}', b'\\mu', mode='math')
-        self.register(u'\N{MICRO SIGN}', b'\\micro', package='gensymb')
+        self.register(u'\N{MICRO SIGN}', u'\\mu', mode='math')
+        self.register(u'\N{MICRO SIGN}', u'\\micro', package='gensymu')
 
-        self.register(u'\N{PILCROW SIGN}', b'\\P')
+        self.register(u'\N{PILCROW SIGN}', u'\\P')
 
-        self.register(u'\N{MIDDLE DOT}', b'\\cdot', mode='math')
+        self.register(u'\N{MIDDLE DOT}', u'\\cdot', mode='math')
         self.register(
             u'\N{MIDDLE DOT}',
-            b'\\textperiodcentered',
+            u'\\textperiodcentered',
             package='textcomp')
 
-        self.register(u'\N{CEDILLA}', b'\\c{}')
+        self.register(u'\N{CEDILLA}', u'\\c{}')
 
-        self.register(u'\N{SUPERSCRIPT ONE}', b'^1', mode='math')
+        self.register(u'\N{SUPERSCRIPT ONE}', u'^1', mode='math')
         self.register(
             u'\N{SUPERSCRIPT ONE}',
-            b'\\textonesuperior',
+            u'\\textonesuperior',
             package='textcomp')
 
-        self.register(u'\N{INVERTED QUESTION MARK}', b'?`')
-        self.register(u'\N{LATIN CAPITAL LETTER A WITH GRAVE}', b'\\`A')
-        self.register(u'\N{LATIN CAPITAL LETTER A WITH CIRCUMFLEX}', b'\\^A')
-        self.register(u'\N{LATIN CAPITAL LETTER A WITH TILDE}', b'\\~A')
-        self.register(u'\N{LATIN CAPITAL LETTER A WITH DIAERESIS}', b'\\"A')
-        self.register(u'\N{LATIN CAPITAL LETTER A WITH RING ABOVE}', b'\\AA')
-        self.register(u'\N{LATIN CAPITAL LETTER A WITH RING ABOVE}', b'\\r A',
+        self.register(u'\N{INVERTED QUESTION MARK}', u'?`')
+        self.register(u'\N{LATIN CAPITAL LETTER A WITH GRAVE}', u'\\`A')
+        self.register(u'\N{LATIN CAPITAL LETTER A WITH CIRCUMFLEX}', u'\\^A')
+        self.register(u'\N{LATIN CAPITAL LETTER A WITH TILDE}', u'\\~A')
+        self.register(u'\N{LATIN CAPITAL LETTER A WITH DIAERESIS}', u'\\"A')
+        self.register(u'\N{LATIN CAPITAL LETTER A WITH RING ABOVE}', u'\\AA')
+        self.register(u'\N{LATIN CAPITAL LETTER A WITH RING ABOVE}', u'\\r A',
                       encode=False)
-        self.register(u'\N{LATIN CAPITAL LETTER AE}', b'\\AE')
-        self.register(u'\N{LATIN CAPITAL LETTER C WITH CEDILLA}', b'\\c C')
-        self.register(u'\N{LATIN CAPITAL LETTER E WITH GRAVE}', b'\\`E')
-        self.register(u'\N{LATIN CAPITAL LETTER E WITH ACUTE}', b"\\'E")
-        self.register(u'\N{LATIN CAPITAL LETTER E WITH CIRCUMFLEX}', b'\\^E')
-        self.register(u'\N{LATIN CAPITAL LETTER E WITH DIAERESIS}', b'\\"E')
-        self.register(u'\N{LATIN CAPITAL LETTER I WITH GRAVE}', b'\\`I')
-        self.register(u'\N{LATIN CAPITAL LETTER I WITH CIRCUMFLEX}', b'\\^I')
-        self.register(u'\N{LATIN CAPITAL LETTER I WITH DIAERESIS}', b'\\"I')
-        self.register(u'\N{LATIN CAPITAL LETTER N WITH TILDE}', b'\\~N')
-        self.register(u'\N{LATIN CAPITAL LETTER O WITH GRAVE}', b'\\`O')
-        self.register(u'\N{LATIN CAPITAL LETTER O WITH ACUTE}', b"\\'O")
-        self.register(u'\N{LATIN CAPITAL LETTER O WITH CIRCUMFLEX}', b'\\^O')
-        self.register(u'\N{LATIN CAPITAL LETTER O WITH TILDE}', b'\\~O')
-        self.register(u'\N{LATIN CAPITAL LETTER O WITH DIAERESIS}', b'\\"O')
-        self.register(u'\N{MULTIPLICATION SIGN}', b'\\times', mode='math')
-        self.register(u'\N{LATIN CAPITAL LETTER O WITH STROKE}', b'\\O')
-        self.register(u'\N{LATIN CAPITAL LETTER U WITH GRAVE}', b'\\`U')
-        self.register(u'\N{LATIN CAPITAL LETTER U WITH ACUTE}', b"\\'U")
-        self.register(u'\N{LATIN CAPITAL LETTER U WITH CIRCUMFLEX}', b'\\^U')
-        self.register(u'\N{LATIN CAPITAL LETTER U WITH DIAERESIS}', b'\\"U')
-        self.register(u'\N{LATIN CAPITAL LETTER Y WITH ACUTE}', b"\\'Y")
-        self.register(u'\N{LATIN SMALL LETTER SHARP S}', b'\\ss')
-        self.register(u'\N{LATIN SMALL LETTER A WITH GRAVE}', b'\\`a')
-        self.register(u'\N{LATIN SMALL LETTER A WITH ACUTE}', b"\\'a")
-        self.register(u'\N{LATIN SMALL LETTER A WITH CIRCUMFLEX}', b'\\^a')
-        self.register(u'\N{LATIN SMALL LETTER A WITH TILDE}', b'\\~a')
-        self.register(u'\N{LATIN SMALL LETTER A WITH DIAERESIS}', b'\\"a')
-        self.register(u'\N{LATIN SMALL LETTER A WITH RING ABOVE}', b'\\aa')
-        self.register(u'\N{LATIN SMALL LETTER A WITH RING ABOVE}', b'\\r a',
+        self.register(u'\N{LATIN CAPITAL LETTER AE}', u'\\AE')
+        self.register(u'\N{LATIN CAPITAL LETTER C WITH CEDILLA}', u'\\c C')
+        self.register(u'\N{LATIN CAPITAL LETTER E WITH GRAVE}', u'\\`E')
+        self.register(u'\N{LATIN CAPITAL LETTER E WITH ACUTE}', u"\\'E")
+        self.register(u'\N{LATIN CAPITAL LETTER E WITH CIRCUMFLEX}', u'\\^E')
+        self.register(u'\N{LATIN CAPITAL LETTER E WITH DIAERESIS}', u'\\"E')
+        self.register(u'\N{LATIN CAPITAL LETTER I WITH GRAVE}', u'\\`I')
+        self.register(u'\N{LATIN CAPITAL LETTER I WITH CIRCUMFLEX}', u'\\^I')
+        self.register(u'\N{LATIN CAPITAL LETTER I WITH DIAERESIS}', u'\\"I')
+        self.register(u'\N{LATIN CAPITAL LETTER N WITH TILDE}', u'\\~N')
+        self.register(u'\N{LATIN CAPITAL LETTER O WITH GRAVE}', u'\\`O')
+        self.register(u'\N{LATIN CAPITAL LETTER O WITH ACUTE}', u"\\'O")
+        self.register(u'\N{LATIN CAPITAL LETTER O WITH CIRCUMFLEX}', u'\\^O')
+        self.register(u'\N{LATIN CAPITAL LETTER O WITH TILDE}', u'\\~O')
+        self.register(u'\N{LATIN CAPITAL LETTER O WITH DIAERESIS}', u'\\"O')
+        self.register(u'\N{MULTIPLICATION SIGN}', u'\\times', mode='math')
+        self.register(u'\N{LATIN CAPITAL LETTER O WITH STROKE}', u'\\O')
+        self.register(u'\N{LATIN CAPITAL LETTER U WITH GRAVE}', u'\\`U')
+        self.register(u'\N{LATIN CAPITAL LETTER U WITH ACUTE}', u"\\'U")
+        self.register(u'\N{LATIN CAPITAL LETTER U WITH CIRCUMFLEX}', u'\\^U')
+        self.register(u'\N{LATIN CAPITAL LETTER U WITH DIAERESIS}', u'\\"U')
+        self.register(u'\N{LATIN CAPITAL LETTER Y WITH ACUTE}', u"\\'Y")
+        self.register(u'\N{LATIN SMALL LETTER SHARP S}', u'\\ss')
+        self.register(u'\N{LATIN SMALL LETTER A WITH GRAVE}', u'\\`a')
+        self.register(u'\N{LATIN SMALL LETTER A WITH ACUTE}', u"\\'a")
+        self.register(u'\N{LATIN SMALL LETTER A WITH CIRCUMFLEX}', u'\\^a')
+        self.register(u'\N{LATIN SMALL LETTER A WITH TILDE}', u'\\~a')
+        self.register(u'\N{LATIN SMALL LETTER A WITH DIAERESIS}', u'\\"a')
+        self.register(u'\N{LATIN SMALL LETTER A WITH RING ABOVE}', u'\\aa')
+        self.register(u'\N{LATIN SMALL LETTER A WITH RING ABOVE}', u'\\r a',
                       encode=False)
-        self.register(u'\N{LATIN SMALL LETTER AE}', b'\\ae')
-        self.register(u'\N{LATIN SMALL LETTER C WITH CEDILLA}', b'\\c c')
-        self.register(u'\N{LATIN SMALL LETTER E WITH GRAVE}', b'\\`e')
-        self.register(u'\N{LATIN SMALL LETTER E WITH ACUTE}', b"\\'e")
-        self.register(u'\N{LATIN SMALL LETTER E WITH CIRCUMFLEX}', b'\\^e')
-        self.register(u'\N{LATIN SMALL LETTER E WITH DIAERESIS}', b'\\"e')
-        self.register(u'\N{LATIN SMALL LETTER I WITH GRAVE}', b'\\`\\i')
-        self.register(u'\N{LATIN SMALL LETTER I WITH GRAVE}', b'\\`i')
-        self.register(u'\N{LATIN SMALL LETTER I WITH ACUTE}', b"\\'\\i")
-        self.register(u'\N{LATIN SMALL LETTER I WITH ACUTE}', b"\\'i")
-        self.register(u'\N{LATIN SMALL LETTER I WITH CIRCUMFLEX}', b'\\^\\i')
-        self.register(u'\N{LATIN SMALL LETTER I WITH CIRCUMFLEX}', b'\\^i')
-        self.register(u'\N{LATIN SMALL LETTER I WITH DIAERESIS}', b'\\"\\i')
-        self.register(u'\N{LATIN SMALL LETTER I WITH DIAERESIS}', b'\\"i')
-        self.register(u'\N{LATIN SMALL LETTER N WITH TILDE}', b'\\~n')
-        self.register(u'\N{LATIN SMALL LETTER O WITH GRAVE}', b'\\`o')
-        self.register(u'\N{LATIN SMALL LETTER O WITH ACUTE}', b"\\'o")
-        self.register(u'\N{LATIN SMALL LETTER O WITH CIRCUMFLEX}', b'\\^o')
-        self.register(u'\N{LATIN SMALL LETTER O WITH TILDE}', b'\\~o')
-        self.register(u'\N{LATIN SMALL LETTER O WITH DIAERESIS}', b'\\"o')
-        self.register(u'\N{DIVISION SIGN}', b'\\div', mode='math')
-        self.register(u'\N{LATIN SMALL LETTER O WITH STROKE}', b'\\o')
-        self.register(u'\N{LATIN SMALL LETTER U WITH GRAVE}', b'\\`u')
-        self.register(u'\N{LATIN SMALL LETTER U WITH ACUTE}', b"\\'u")
-        self.register(u'\N{LATIN SMALL LETTER U WITH CIRCUMFLEX}', b'\\^u')
-        self.register(u'\N{LATIN SMALL LETTER U WITH DIAERESIS}', b'\\"u')
-        self.register(u'\N{LATIN SMALL LETTER Y WITH ACUTE}', b"\\'y")
-        self.register(u'\N{LATIN SMALL LETTER Y WITH DIAERESIS}', b'\\"y')
-        self.register(u'\N{LATIN CAPITAL LETTER A WITH MACRON}', b'\\=A')
-        self.register(u'\N{LATIN SMALL LETTER A WITH MACRON}', b'\\=a')
-        self.register(u'\N{LATIN CAPITAL LETTER A WITH BREVE}', b'\\u A')
-        self.register(u'\N{LATIN SMALL LETTER A WITH BREVE}', b'\\u a')
-        self.register(u'\N{LATIN CAPITAL LETTER A WITH OGONEK}', b'\\k A')
-        self.register(u'\N{LATIN SMALL LETTER A WITH OGONEK}', b'\\k a')
-        self.register(u'\N{LATIN CAPITAL LETTER C WITH ACUTE}', b"\\'C")
-        self.register(u'\N{LATIN SMALL LETTER C WITH ACUTE}', b"\\'c")
-        self.register(u'\N{LATIN CAPITAL LETTER C WITH CIRCUMFLEX}', b'\\^C')
-        self.register(u'\N{LATIN SMALL LETTER C WITH CIRCUMFLEX}', b'\\^c')
-        self.register(u'\N{LATIN CAPITAL LETTER C WITH DOT ABOVE}', b'\\.C')
-        self.register(u'\N{LATIN SMALL LETTER C WITH DOT ABOVE}', b'\\.c')
-        self.register(u'\N{LATIN CAPITAL LETTER C WITH CARON}', b'\\v C')
-        self.register(u'\N{LATIN SMALL LETTER C WITH CARON}', b'\\v c')
-        self.register(u'\N{LATIN CAPITAL LETTER D WITH CARON}', b'\\v D')
-        self.register(u'\N{LATIN SMALL LETTER D WITH CARON}', b'\\v d')
-        self.register(u'\N{LATIN CAPITAL LETTER E WITH MACRON}', b'\\=E')
-        self.register(u'\N{LATIN SMALL LETTER E WITH MACRON}', b'\\=e')
-        self.register(u'\N{LATIN CAPITAL LETTER E WITH BREVE}', b'\\u E')
-        self.register(u'\N{LATIN SMALL LETTER E WITH BREVE}', b'\\u e')
-        self.register(u'\N{LATIN CAPITAL LETTER E WITH DOT ABOVE}', b'\\.E')
-        self.register(u'\N{LATIN SMALL LETTER E WITH DOT ABOVE}', b'\\.e')
-        self.register(u'\N{LATIN CAPITAL LETTER E WITH OGONEK}', b'\\k E')
-        self.register(u'\N{LATIN SMALL LETTER E WITH OGONEK}', b'\\k e')
-        self.register(u'\N{LATIN CAPITAL LETTER E WITH CARON}', b'\\v E')
-        self.register(u'\N{LATIN SMALL LETTER E WITH CARON}', b'\\v e')
-        self.register(u'\N{LATIN CAPITAL LETTER G WITH CIRCUMFLEX}', b'\\^G')
-        self.register(u'\N{LATIN SMALL LETTER G WITH CIRCUMFLEX}', b'\\^g')
-        self.register(u'\N{LATIN CAPITAL LETTER G WITH BREVE}', b'\\u G')
-        self.register(u'\N{LATIN SMALL LETTER G WITH BREVE}', b'\\u g')
-        self.register(u'\N{LATIN CAPITAL LETTER G WITH DOT ABOVE}', b'\\.G')
-        self.register(u'\N{LATIN SMALL LETTER G WITH DOT ABOVE}', b'\\.g')
-        self.register(u'\N{LATIN CAPITAL LETTER G WITH CEDILLA}', b'\\c G')
-        self.register(u'\N{LATIN SMALL LETTER G WITH CEDILLA}', b'\\c g')
-        self.register(u'\N{LATIN CAPITAL LETTER H WITH CIRCUMFLEX}', b'\\^H')
-        self.register(u'\N{LATIN SMALL LETTER H WITH CIRCUMFLEX}', b'\\^h')
-        self.register(u'\N{LATIN CAPITAL LETTER I WITH TILDE}', b'\\~I')
-        self.register(u'\N{LATIN SMALL LETTER I WITH TILDE}', b'\\~\\i')
-        self.register(u'\N{LATIN SMALL LETTER I WITH TILDE}', b'\\~i')
-        self.register(u'\N{LATIN CAPITAL LETTER I WITH MACRON}', b'\\=I')
-        self.register(u'\N{LATIN SMALL LETTER I WITH MACRON}', b'\\=\\i')
-        self.register(u'\N{LATIN SMALL LETTER I WITH MACRON}', b'\\=i')
-        self.register(u'\N{LATIN CAPITAL LETTER I WITH BREVE}', b'\\u I')
-        self.register(u'\N{LATIN SMALL LETTER I WITH BREVE}', b'\\u\\i')
-        self.register(u'\N{LATIN SMALL LETTER I WITH BREVE}', b'\\u i')
-        self.register(u'\N{LATIN CAPITAL LETTER I WITH OGONEK}', b'\\k I')
-        self.register(u'\N{LATIN SMALL LETTER I WITH OGONEK}', b'\\k i')
-        self.register(u'\N{LATIN CAPITAL LETTER I WITH DOT ABOVE}', b'\\.I')
-        self.register(u'\N{LATIN SMALL LETTER DOTLESS I}', b'\\i')
-        self.register(u'\N{LATIN CAPITAL LIGATURE IJ}', b'IJ', decode=False)
-        self.register(u'\N{LATIN SMALL LIGATURE IJ}', b'ij', decode=False)
-        self.register(u'\N{LATIN CAPITAL LETTER J WITH CIRCUMFLEX}', b'\\^J')
-        self.register(u'\N{LATIN SMALL LETTER J WITH CIRCUMFLEX}', b'\\^\\j')
-        self.register(u'\N{LATIN SMALL LETTER J WITH CIRCUMFLEX}', b'\\^j')
-        self.register(u'\N{LATIN CAPITAL LETTER K WITH CEDILLA}', b'\\c K')
-        self.register(u'\N{LATIN SMALL LETTER K WITH CEDILLA}', b'\\c k')
-        self.register(u'\N{LATIN CAPITAL LETTER L WITH ACUTE}', b"\\'L")
-        self.register(u'\N{LATIN SMALL LETTER L WITH ACUTE}', b"\\'l")
-        self.register(u'\N{LATIN CAPITAL LETTER L WITH CEDILLA}', b'\\c L')
-        self.register(u'\N{LATIN SMALL LETTER L WITH CEDILLA}', b'\\c l')
-        self.register(u'\N{LATIN CAPITAL LETTER L WITH CARON}', b'\\v L')
-        self.register(u'\N{LATIN SMALL LETTER L WITH CARON}', b'\\v l')
-        self.register(u'\N{LATIN CAPITAL LETTER L WITH STROKE}', b'\\L')
-        self.register(u'\N{LATIN SMALL LETTER L WITH STROKE}', b'\\l')
-        self.register(u'\N{LATIN CAPITAL LETTER N WITH ACUTE}', b"\\'N")
-        self.register(u'\N{LATIN SMALL LETTER N WITH ACUTE}', b"\\'n")
-        self.register(u'\N{LATIN CAPITAL LETTER N WITH CEDILLA}', b'\\c N')
-        self.register(u'\N{LATIN SMALL LETTER N WITH CEDILLA}', b'\\c n')
-        self.register(u'\N{LATIN CAPITAL LETTER N WITH CARON}', b'\\v N')
-        self.register(u'\N{LATIN SMALL LETTER N WITH CARON}', b'\\v n')
-        self.register(u'\N{LATIN CAPITAL LETTER O WITH MACRON}', b'\\=O')
-        self.register(u'\N{LATIN SMALL LETTER O WITH MACRON}', b'\\=o')
-        self.register(u'\N{LATIN CAPITAL LETTER O WITH BREVE}', b'\\u O')
-        self.register(u'\N{LATIN SMALL LETTER O WITH BREVE}', b'\\u o')
+        self.register(u'\N{LATIN SMALL LETTER AE}', u'\\ae')
+        self.register(u'\N{LATIN SMALL LETTER C WITH CEDILLA}', u'\\c c')
+        self.register(u'\N{LATIN SMALL LETTER E WITH GRAVE}', u'\\`e')
+        self.register(u'\N{LATIN SMALL LETTER E WITH ACUTE}', u"\\'e")
+        self.register(u'\N{LATIN SMALL LETTER E WITH CIRCUMFLEX}', u'\\^e')
+        self.register(u'\N{LATIN SMALL LETTER E WITH DIAERESIS}', u'\\"e')
+        self.register(u'\N{LATIN SMALL LETTER I WITH GRAVE}', u'\\`\\i')
+        self.register(u'\N{LATIN SMALL LETTER I WITH GRAVE}', u'\\`i')
+        self.register(u'\N{LATIN SMALL LETTER I WITH ACUTE}', u"\\'\\i")
+        self.register(u'\N{LATIN SMALL LETTER I WITH ACUTE}', u"\\'i")
+        self.register(u'\N{LATIN SMALL LETTER I WITH CIRCUMFLEX}', u'\\^\\i')
+        self.register(u'\N{LATIN SMALL LETTER I WITH CIRCUMFLEX}', u'\\^i')
+        self.register(u'\N{LATIN SMALL LETTER I WITH DIAERESIS}', u'\\"\\i') 
+        self.register(u'\N{LATIN SMALL LETTER I WITH DIAERESIS}', u'\\"i')
+        self.register(u'\N{LATIN SMALL LETTER N WITH TILDE}', u'\\~n')
+        self.register(u'\N{LATIN SMALL LETTER O WITH GRAVE}', u'\\`o')
+        self.register(u'\N{LATIN SMALL LETTER O WITH ACUTE}', u"\\'o")
+        self.register(u'\N{LATIN SMALL LETTER O WITH CIRCUMFLEX}', u'\\^o')
+        self.register(u'\N{LATIN SMALL LETTER O WITH TILDE}', u'\\~o')
+        self.register(u'\N{LATIN SMALL LETTER O WITH DIAERESIS}', u'\\"o')
+        self.register(u'\N{DIVISION SIGN}', u'\\div', mode='math')
+        self.register(u'\N{LATIN SMALL LETTER O WITH STROKE}', u'\\o')
+        self.register(u'\N{LATIN SMALL LETTER U WITH GRAVE}', u'\\`u')
+        self.register(u'\N{LATIN SMALL LETTER U WITH ACUTE}', u"\\'u")
+        self.register(u'\N{LATIN SMALL LETTER U WITH CIRCUMFLEX}', u'\\^u')
+        self.register(u'\N{LATIN SMALL LETTER U WITH DIAERESIS}', u'\\"u')
+        self.register(u'\N{LATIN SMALL LETTER Y WITH ACUTE}', u"\\'y")
+        self.register(u'\N{LATIN SMALL LETTER Y WITH DIAERESIS}', u'\\"y')
+        self.register(u'\N{LATIN CAPITAL LETTER A WITH MACRON}', u'\\=A')
+        self.register(u'\N{LATIN SMALL LETTER A WITH MACRON}', u'\\=a')
+        self.register(u'\N{LATIN CAPITAL LETTER A WITH BREVE}', u'\\u A')
+        self.register(u'\N{LATIN SMALL LETTER A WITH BREVE}', u'\\u a')
+        self.register(u'\N{LATIN CAPITAL LETTER A WITH OGONEK}', u'\\k A')
+        self.register(u'\N{LATIN SMALL LETTER A WITH OGONEK}', u'\\k a')
+        self.register(u'\N{LATIN CAPITAL LETTER C WITH ACUTE}', u"\\'C")
+        self.register(u'\N{LATIN SMALL LETTER C WITH ACUTE}', u"\\'c")
+        self.register(u'\N{LATIN CAPITAL LETTER C WITH CIRCUMFLEX}', u'\\^C')
+        self.register(u'\N{LATIN SMALL LETTER C WITH CIRCUMFLEX}', u'\\^c')
+        self.register(u'\N{LATIN CAPITAL LETTER C WITH DOT ABOVE}', u'\\.C')
+        self.register(u'\N{LATIN SMALL LETTER C WITH DOT ABOVE}', u'\\.c')
+        self.register(u'\N{LATIN CAPITAL LETTER C WITH CARON}', u'\\v C')
+        self.register(u'\N{LATIN SMALL LETTER C WITH CARON}', u'\\v c')
+        self.register(u'\N{LATIN CAPITAL LETTER D WITH CARON}', u'\\v D')
+        self.register(u'\N{LATIN SMALL LETTER D WITH CARON}', u'\\v d')
+        self.register(u'\N{LATIN CAPITAL LETTER E WITH MACRON}', u'\\=E')
+        self.register(u'\N{LATIN SMALL LETTER E WITH MACRON}', u'\\=e')
+        self.register(u'\N{LATIN CAPITAL LETTER E WITH BREVE}', u'\\u E')
+        self.register(u'\N{LATIN SMALL LETTER E WITH BREVE}', u'\\u e')
+        self.register(u'\N{LATIN CAPITAL LETTER E WITH DOT ABOVE}', u'\\.E')
+        self.register(u'\N{LATIN SMALL LETTER E WITH DOT ABOVE}', u'\\.e')
+        self.register(u'\N{LATIN CAPITAL LETTER E WITH OGONEK}', u'\\k E')
+        self.register(u'\N{LATIN SMALL LETTER E WITH OGONEK}', u'\\k e')
+        self.register(u'\N{LATIN CAPITAL LETTER E WITH CARON}', u'\\v E')
+        self.register(u'\N{LATIN SMALL LETTER E WITH CARON}', u'\\v e')
+        self.register(u'\N{LATIN CAPITAL LETTER G WITH CIRCUMFLEX}', u'\\^G')
+        self.register(u'\N{LATIN SMALL LETTER G WITH CIRCUMFLEX}', u'\\^g')
+        self.register(u'\N{LATIN CAPITAL LETTER G WITH BREVE}', u'\\u G')
+        self.register(u'\N{LATIN SMALL LETTER G WITH BREVE}', u'\\u g')
+        self.register(u'\N{LATIN CAPITAL LETTER G WITH DOT ABOVE}', u'\\.G')
+        self.register(u'\N{LATIN SMALL LETTER G WITH DOT ABOVE}', u'\\.g')
+        self.register(u'\N{LATIN CAPITAL LETTER G WITH CEDILLA}', u'\\c G')
+        self.register(u'\N{LATIN SMALL LETTER G WITH CEDILLA}', u'\\c g')
+        self.register(u'\N{LATIN CAPITAL LETTER H WITH CIRCUMFLEX}', u'\\^H')
+        self.register(u'\N{LATIN SMALL LETTER H WITH CIRCUMFLEX}', u'\\^h')
+        self.register(u'\N{LATIN CAPITAL LETTER I WITH TILDE}', u'\\~I')
+        self.register(u'\N{LATIN SMALL LETTER I WITH TILDE}', u'\\~\\i')
+        self.register(u'\N{LATIN SMALL LETTER I WITH TILDE}', u'\\~i')
+        self.register(u'\N{LATIN CAPITAL LETTER I WITH MACRON}', u'\\=I')
+        self.register(u'\N{LATIN SMALL LETTER I WITH MACRON}', u'\\=\\i')
+        self.register(u'\N{LATIN SMALL LETTER I WITH MACRON}', u'\\=i')
+        self.register(u'\N{LATIN CAPITAL LETTER I WITH BREVE}', u'\\u I')
+        self.register(u'\N{LATIN SMALL LETTER I WITH BREVE}', u'\\u\\i')
+        self.register(u'\N{LATIN SMALL LETTER I WITH BREVE}', u'\\u i')
+        self.register(u'\N{LATIN CAPITAL LETTER I WITH OGONEK}', u'\\k I')
+        self.register(u'\N{LATIN SMALL LETTER I WITH OGONEK}', u'\\k i')
+        self.register(u'\N{LATIN CAPITAL LETTER I WITH DOT ABOVE}', u'\\.I')
+        self.register(u'\N{LATIN SMALL LETTER DOTLESS I}', u'\\i')
+        self.register(u'\N{LATIN CAPITAL LIGATURE IJ}', u'IJ', decode=False)
+        self.register(u'\N{LATIN SMALL LIGATURE IJ}', u'ij', decode=False)
+        self.register(u'\N{LATIN CAPITAL LETTER J WITH CIRCUMFLEX}', u'\\^J')
+        self.register(u'\N{LATIN SMALL LETTER J WITH CIRCUMFLEX}', u'\\^\\j')
+        self.register(u'\N{LATIN SMALL LETTER J WITH CIRCUMFLEX}', u'\\^j')
+        self.register(u'\N{LATIN CAPITAL LETTER K WITH CEDILLA}', u'\\c K')
+        self.register(u'\N{LATIN SMALL LETTER K WITH CEDILLA}', u'\\c k')
+        self.register(u'\N{LATIN CAPITAL LETTER L WITH ACUTE}', u"\\'L")
+        self.register(u'\N{LATIN SMALL LETTER L WITH ACUTE}', u"\\'l")
+        self.register(u'\N{LATIN CAPITAL LETTER L WITH CEDILLA}', u'\\c L')
+        self.register(u'\N{LATIN SMALL LETTER L WITH CEDILLA}', u'\\c l')
+        self.register(u'\N{LATIN CAPITAL LETTER L WITH CARON}', u'\\v L')
+        self.register(u'\N{LATIN SMALL LETTER L WITH CARON}', u'\\v l')
+        self.register(u'\N{LATIN CAPITAL LETTER L WITH STROKE}', u'\\L')
+        self.register(u'\N{LATIN SMALL LETTER L WITH STROKE}', u'\\l')
+        self.register(u'\N{LATIN CAPITAL LETTER N WITH ACUTE}', u"\\'N")
+        self.register(u'\N{LATIN SMALL LETTER N WITH ACUTE}', u"\\'n")
+        self.register(u'\N{LATIN CAPITAL LETTER N WITH CEDILLA}', u'\\c N')
+        self.register(u'\N{LATIN SMALL LETTER N WITH CEDILLA}', u'\\c n')
+        self.register(u'\N{LATIN CAPITAL LETTER N WITH CARON}', u'\\v N')
+        self.register(u'\N{LATIN SMALL LETTER N WITH CARON}', u'\\v n')
+        self.register(u'\N{LATIN CAPITAL LETTER O WITH MACRON}', u'\\=O')
+        self.register(u'\N{LATIN SMALL LETTER O WITH MACRON}', u'\\=o')
+        self.register(u'\N{LATIN CAPITAL LETTER O WITH BREVE}', u'\\u O')
+        self.register(u'\N{LATIN SMALL LETTER O WITH BREVE}', u'\\u o')
         self.register(
             u'\N{LATIN CAPITAL LETTER O WITH DOUBLE ACUTE}',
-            b'\\H O')
-        self.register(u'\N{LATIN SMALL LETTER O WITH DOUBLE ACUTE}', b'\\H o')
-        self.register(u'\N{LATIN CAPITAL LIGATURE OE}', b'\\OE')
-        self.register(u'\N{LATIN SMALL LIGATURE OE}', b'\\oe')
-        self.register(u'\N{LATIN CAPITAL LETTER R WITH ACUTE}', b"\\'R")
-        self.register(u'\N{LATIN SMALL LETTER R WITH ACUTE}', b"\\'r")
-        self.register(u'\N{LATIN CAPITAL LETTER R WITH CEDILLA}', b'\\c R')
-        self.register(u'\N{LATIN SMALL LETTER R WITH CEDILLA}', b'\\c r')
-        self.register(u'\N{LATIN CAPITAL LETTER R WITH CARON}', b'\\v R')
-        self.register(u'\N{LATIN SMALL LETTER R WITH CARON}', b'\\v r')
-        self.register(u'\N{LATIN CAPITAL LETTER S WITH ACUTE}', b"\\'S")
-        self.register(u'\N{LATIN SMALL LETTER S WITH ACUTE}', b"\\'s")
-        self.register(u'\N{LATIN CAPITAL LETTER S WITH CIRCUMFLEX}', b'\\^S')
-        self.register(u'\N{LATIN SMALL LETTER S WITH CIRCUMFLEX}', b'\\^s')
-        self.register(u'\N{LATIN CAPITAL LETTER S WITH CEDILLA}', b'\\c S')
-        self.register(u'\N{LATIN SMALL LETTER S WITH CEDILLA}', b'\\c s')
-        self.register(u'\N{LATIN CAPITAL LETTER S WITH CARON}', b'\\v S')
-        self.register(u'\N{LATIN SMALL LETTER S WITH CARON}', b'\\v s')
-        self.register(u'\N{LATIN CAPITAL LETTER T WITH CEDILLA}', b'\\c T')
-        self.register(u'\N{LATIN SMALL LETTER T WITH CEDILLA}', b'\\c t')
-        self.register(u'\N{LATIN CAPITAL LETTER T WITH CARON}', b'\\v T')
-        self.register(u'\N{LATIN SMALL LETTER T WITH CARON}', b'\\v t')
-        self.register(u'\N{LATIN CAPITAL LETTER U WITH TILDE}', b'\\~U')
-        self.register(u'\N{LATIN SMALL LETTER U WITH TILDE}', b'\\~u')
-        self.register(u'\N{LATIN CAPITAL LETTER U WITH MACRON}', b'\\=U')
-        self.register(u'\N{LATIN SMALL LETTER U WITH MACRON}', b'\\=u')
-        self.register(u'\N{LATIN CAPITAL LETTER U WITH BREVE}', b'\\u U')
-        self.register(u'\N{LATIN SMALL LETTER U WITH BREVE}', b'\\u u')
-        self.register(u'\N{LATIN CAPITAL LETTER U WITH RING ABOVE}', b'\\r U')
-        self.register(u'\N{LATIN SMALL LETTER U WITH RING ABOVE}', b'\\r u')
+            u'\\H O')
+        self.register(u'\N{LATIN SMALL LETTER O WITH DOUBLE ACUTE}', u'\\H o')
+        self.register(u'\N{LATIN CAPITAL LIGATURE OE}', u'\\OE')
+        self.register(u'\N{LATIN SMALL LIGATURE OE}', u'\\oe')
+        self.register(u'\N{LATIN CAPITAL LETTER R WITH ACUTE}', u"\\'R")
+        self.register(u'\N{LATIN SMALL LETTER R WITH ACUTE}', u"\\'r")
+        self.register(u'\N{LATIN CAPITAL LETTER R WITH CEDILLA}', u'\\c R')
+        self.register(u'\N{LATIN SMALL LETTER R WITH CEDILLA}', u'\\c r')
+        self.register(u'\N{LATIN CAPITAL LETTER R WITH CARON}', u'\\v R')
+        self.register(u'\N{LATIN SMALL LETTER R WITH CARON}', u'\\v r')
+        self.register(u'\N{LATIN CAPITAL LETTER S WITH ACUTE}', u"\\'S")
+        self.register(u'\N{LATIN SMALL LETTER S WITH ACUTE}', u"\\'s")
+        self.register(u'\N{LATIN CAPITAL LETTER S WITH CIRCUMFLEX}', u'\\^S')
+        self.register(u'\N{LATIN SMALL LETTER S WITH CIRCUMFLEX}', u'\\^s')
+        self.register(u'\N{LATIN CAPITAL LETTER S WITH CEDILLA}', u'\\c S')
+        self.register(u'\N{LATIN SMALL LETTER S WITH CEDILLA}', u'\\c s')
+        self.register(u'\N{LATIN CAPITAL LETTER S WITH CARON}', u'\\v S')
+        self.register(u'\N{LATIN SMALL LETTER S WITH CARON}', u'\\v s')
+        self.register(u'\N{LATIN CAPITAL LETTER T WITH CEDILLA}', u'\\c T')
+        self.register(u'\N{LATIN SMALL LETTER T WITH CEDILLA}', u'\\c t')
+        self.register(u'\N{LATIN CAPITAL LETTER T WITH CARON}', u'\\v T')
+        self.register(u'\N{LATIN SMALL LETTER T WITH CARON}', u'\\v t')
+        self.register(u'\N{LATIN CAPITAL LETTER U WITH TILDE}', u'\\~U')
+        self.register(u'\N{LATIN SMALL LETTER U WITH TILDE}', u'\\~u')
+        self.register(u'\N{LATIN CAPITAL LETTER U WITH MACRON}', u'\\=U')
+        self.register(u'\N{LATIN SMALL LETTER U WITH MACRON}', u'\\=u')
+        self.register(u'\N{LATIN CAPITAL LETTER U WITH BREVE}', u'\\u U')
+        self.register(u'\N{LATIN SMALL LETTER U WITH BREVE}', u'\\u u')
+        self.register(u'\N{LATIN CAPITAL LETTER U WITH RING ABOVE}', u'\\r U')
+        self.register(u'\N{LATIN SMALL LETTER U WITH RING ABOVE}', u'\\r u')
         self.register(
             u'\N{LATIN CAPITAL LETTER U WITH DOUBLE ACUTE}',
-            b'\\H U')
-        self.register(u'\N{LATIN SMALL LETTER U WITH DOUBLE ACUTE}', b'\\H u')
-        self.register(u'\N{LATIN CAPITAL LETTER U WITH OGONEK}', b'\\k U')
-        self.register(u'\N{LATIN SMALL LETTER U WITH OGONEK}', b'\\k u')
-        self.register(u'\N{LATIN CAPITAL LETTER W WITH CIRCUMFLEX}', b'\\^W')
-        self.register(u'\N{LATIN SMALL LETTER W WITH CIRCUMFLEX}', b'\\^w')
-        self.register(u'\N{LATIN CAPITAL LETTER Y WITH CIRCUMFLEX}', b'\\^Y')
-        self.register(u'\N{LATIN SMALL LETTER Y WITH CIRCUMFLEX}', b'\\^y')
-        self.register(u'\N{LATIN CAPITAL LETTER Y WITH DIAERESIS}', b'\\"Y')
-        self.register(u'\N{LATIN CAPITAL LETTER Z WITH ACUTE}', b"\\'Z")
-        self.register(u'\N{LATIN SMALL LETTER Z WITH ACUTE}', b"\\'z")
-        self.register(u'\N{LATIN CAPITAL LETTER Z WITH DOT ABOVE}', b'\\.Z')
-        self.register(u'\N{LATIN SMALL LETTER Z WITH DOT ABOVE}', b'\\.z')
-        self.register(u'\N{LATIN CAPITAL LETTER Z WITH CARON}', b'\\v Z')
-        self.register(u'\N{LATIN SMALL LETTER Z WITH CARON}', b'\\v z')
-        self.register(u'\N{LATIN CAPITAL LETTER DZ WITH CARON}', b'D\\v Z')
+            u'\\H U')
+        self.register(u'\N{LATIN SMALL LETTER U WITH DOUBLE ACUTE}', u'\\H u')
+        self.register(u'\N{LATIN CAPITAL LETTER U WITH OGONEK}', u'\\k U')
+        self.register(u'\N{LATIN SMALL LETTER U WITH OGONEK}', u'\\k u')
+        self.register(u'\N{LATIN CAPITAL LETTER W WITH CIRCUMFLEX}', u'\\^W')
+        self.register(u'\N{LATIN SMALL LETTER W WITH CIRCUMFLEX}', u'\\^w')
+        self.register(u'\N{LATIN CAPITAL LETTER Y WITH CIRCUMFLEX}', u'\\^Y')
+        self.register(u'\N{LATIN SMALL LETTER Y WITH CIRCUMFLEX}', u'\\^y')
+        self.register(u'\N{LATIN CAPITAL LETTER Y WITH DIAERESIS}', u'\\"Y')
+        self.register(u'\N{LATIN CAPITAL LETTER Z WITH ACUTE}', u"\\'Z")
+        self.register(u'\N{LATIN SMALL LETTER Z WITH ACUTE}', u"\\'z")
+        self.register(u'\N{LATIN CAPITAL LETTER Z WITH DOT ABOVE}', u'\\.Z')
+        self.register(u'\N{LATIN SMALL LETTER Z WITH DOT ABOVE}', u'\\.z')
+        self.register(u'\N{LATIN CAPITAL LETTER Z WITH CARON}', u'\\v Z')
+        self.register(u'\N{LATIN SMALL LETTER Z WITH CARON}', u'\\v z')
+        self.register(u'\N{LATIN CAPITAL LETTER DZ WITH CARON}', u'D\\v Z')
         self.register(
             u'\N{LATIN CAPITAL LETTER D WITH SMALL LETTER Z WITH CARON}',
-            b'D\\v z')
-        self.register(u'\N{LATIN SMALL LETTER DZ WITH CARON}', b'd\\v z')
-        self.register(u'\N{LATIN CAPITAL LETTER LJ}', b'LJ', decode=False)
+            u'D\\v z')
+        self.register(u'\N{LATIN SMALL LETTER DZ WITH CARON}', u'd\\v z')
+        self.register(u'\N{LATIN CAPITAL LETTER LJ}', u'LJ', decode=False)
         self.register(
             u'\N{LATIN CAPITAL LETTER L WITH SMALL LETTER J}',
-            b'Lj',
+            u'Lj',
             decode=False)
-        self.register(u'\N{LATIN SMALL LETTER LJ}', b'lj', decode=False)
-        self.register(u'\N{LATIN CAPITAL LETTER NJ}', b'NJ', decode=False)
+        self.register(u'\N{LATIN SMALL LETTER LJ}', u'lj', decode=False)
+        self.register(u'\N{LATIN CAPITAL LETTER NJ}', u'NJ', decode=False)
         self.register(
             u'\N{LATIN CAPITAL LETTER N WITH SMALL LETTER J}',
-            b'Nj',
+            u'Nj',
             decode=False)
-        self.register(u'\N{LATIN SMALL LETTER NJ}', b'nj', decode=False)
-        self.register(u'\N{LATIN CAPITAL LETTER A WITH CARON}', b'\\v A')
-        self.register(u'\N{LATIN SMALL LETTER A WITH CARON}', b'\\v a')
-        self.register(u'\N{LATIN CAPITAL LETTER I WITH CARON}', b'\\v I')
-        self.register(u'\N{LATIN SMALL LETTER I WITH CARON}', b'\\v\\i')
-        self.register(u'\N{LATIN CAPITAL LETTER O WITH CARON}', b'\\v O')
-        self.register(u'\N{LATIN SMALL LETTER O WITH CARON}', b'\\v o')
-        self.register(u'\N{LATIN CAPITAL LETTER U WITH CARON}', b'\\v U')
-        self.register(u'\N{LATIN SMALL LETTER U WITH CARON}', b'\\v u')
-        self.register(u'\N{LATIN CAPITAL LETTER G WITH CARON}', b'\\v G')
-        self.register(u'\N{LATIN SMALL LETTER G WITH CARON}', b'\\v g')
-        self.register(u'\N{LATIN CAPITAL LETTER K WITH CARON}', b'\\v K')
-        self.register(u'\N{LATIN SMALL LETTER K WITH CARON}', b'\\v k')
-        self.register(u'\N{LATIN CAPITAL LETTER O WITH OGONEK}', b'\\k O')
-        self.register(u'\N{LATIN SMALL LETTER O WITH OGONEK}', b'\\k o')
-        self.register(u'\N{LATIN SMALL LETTER J WITH CARON}', b'\\v\\j')
-        self.register(u'\N{LATIN CAPITAL LETTER DZ}', b'DZ', decode=False)
+        self.register(u'\N{LATIN SMALL LETTER NJ}', u'nj', decode=False)
+        self.register(u'\N{LATIN CAPITAL LETTER A WITH CARON}', u'\\v A')
+        self.register(u'\N{LATIN SMALL LETTER A WITH CARON}', u'\\v a')
+        self.register(u'\N{LATIN CAPITAL LETTER I WITH CARON}', u'\\v I')
+        self.register(u'\N{LATIN SMALL LETTER I WITH CARON}', u'\\v\\i')
+        self.register(u'\N{LATIN CAPITAL LETTER O WITH CARON}', u'\\v O')
+        self.register(u'\N{LATIN SMALL LETTER O WITH CARON}', u'\\v o')
+        self.register(u'\N{LATIN CAPITAL LETTER U WITH CARON}', u'\\v U')
+        self.register(u'\N{LATIN SMALL LETTER U WITH CARON}', u'\\v u')
+        self.register(u'\N{LATIN CAPITAL LETTER G WITH CARON}', u'\\v G')
+        self.register(u'\N{LATIN SMALL LETTER G WITH CARON}', u'\\v g')
+        self.register(u'\N{LATIN CAPITAL LETTER K WITH CARON}', u'\\v K')
+        self.register(u'\N{LATIN SMALL LETTER K WITH CARON}', u'\\v k')
+        self.register(u'\N{LATIN CAPITAL LETTER O WITH OGONEK}', u'\\k O')
+        self.register(u'\N{LATIN SMALL LETTER O WITH OGONEK}', u'\\k o')
+        self.register(u'\N{LATIN SMALL LETTER J WITH CARON}', u'\\v\\j')
+        self.register(u'\N{LATIN CAPITAL LETTER DZ}', u'DZ', decode=False)
         self.register(
             u'\N{LATIN CAPITAL LETTER D WITH SMALL LETTER Z}',
-            b'Dz',
+            u'Dz',
             decode=False)
-        self.register(u'\N{LATIN SMALL LETTER DZ}', b'dz', decode=False)
-        self.register(u'\N{LATIN CAPITAL LETTER G WITH ACUTE}', b"\\'G")
-        self.register(u'\N{LATIN SMALL LETTER G WITH ACUTE}', b"\\'g")
-        self.register(u'\N{LATIN CAPITAL LETTER AE WITH ACUTE}', b"\\'\\AE")
-        self.register(u'\N{LATIN SMALL LETTER AE WITH ACUTE}', b"\\'\\ae")
+        self.register(u'\N{LATIN SMALL LETTER DZ}', u'dz', decode=False)
+        self.register(u'\N{LATIN CAPITAL LETTER G WITH ACUTE}', u"\\'G")
+        self.register(u'\N{LATIN SMALL LETTER G WITH ACUTE}', u"\\'g")
+        self.register(u'\N{LATIN CAPITAL LETTER AE WITH ACUTE}', u"\\'\\AE")
+        self.register(u'\N{LATIN SMALL LETTER AE WITH ACUTE}', u"\\'\\ae")
         self.register(
             u'\N{LATIN CAPITAL LETTER O WITH STROKE AND ACUTE}',
-            b"\\'\\O")
+            u"\\'\\O")
         self.register(
             u'\N{LATIN SMALL LETTER O WITH STROKE AND ACUTE}',
-            b"\\'\\o")
-        self.register(u'\N{LATIN CAPITAL LETTER ETH}', b'\\DH')
-        self.register(u'\N{LATIN SMALL LETTER ETH}', b'\\dh')
-        self.register(u'\N{LATIN CAPITAL LETTER THORN}', b'\\TH')
-        self.register(u'\N{LATIN SMALL LETTER THORN}', b'\\th')
-        self.register(u'\N{LATIN CAPITAL LETTER D WITH DOT BELOW}', b'\\d D')
-        self.register(u'\N{LATIN SMALL LETTER D WITH DOT BELOW}', b'\\d d')
-        self.register(u'\N{LATIN CAPITAL LETTER L WITH DOT BELOW}', b'\\d L')
-        self.register(u'\N{LATIN SMALL LETTER L WITH DOT BELOW}', b'\\d l')
-        self.register(u'\N{LATIN CAPITAL LETTER M WITH DOT BELOW}', b'\\d M')
-        self.register(u'\N{LATIN SMALL LETTER M WITH DOT BELOW}', b'\\d m')
-        self.register(u'\N{LATIN CAPITAL LETTER N WITH DOT BELOW}', b'\\d N')
-        self.register(u'\N{LATIN SMALL LETTER N WITH DOT BELOW}', b'\\d n')
-        self.register(u'\N{LATIN CAPITAL LETTER R WITH DOT BELOW}', b'\\d R')
-        self.register(u'\N{LATIN SMALL LETTER R WITH DOT BELOW}', b'\\d r')
-        self.register(u'\N{LATIN CAPITAL LETTER S WITH DOT BELOW}', b'\\d S')
-        self.register(u'\N{LATIN SMALL LETTER S WITH DOT BELOW}', b'\\d s')
-        self.register(u'\N{LATIN CAPITAL LETTER T WITH DOT BELOW}', b'\\d T')
-        self.register(u'\N{LATIN SMALL LETTER T WITH DOT BELOW}', b'\\d t')
-        self.register(u'\N{PARTIAL DIFFERENTIAL}', b'\\partial', mode='math')
-        self.register(u'\N{N-ARY PRODUCT}', b'\\prod', mode='math')
-        self.register(u'\N{N-ARY SUMMATION}', b'\\sum', mode='math')
-        self.register(u'\N{SQUARE ROOT}', b'\\surd', mode='math')
-        self.register(u'\N{INFINITY}', b'\\infty', mode='math')
-        self.register(u'\N{INTEGRAL}', b'\\int', mode='math')
-        self.register(u'\N{INTERSECTION}', b'\\cap', mode='math')
-        self.register(u'\N{UNION}', b'\\cup', mode='math')
-        self.register(u'\N{RIGHTWARDS ARROW}', b'\\rightarrow', mode='math')
+            u"\\'\\o")
+        self.register(u'\N{LATIN CAPITAL LETTER ETH}', u'\\DH')
+        self.register(u'\N{LATIN SMALL LETTER ETH}', u'\\dh')
+        self.register(u'\N{LATIN CAPITAL LETTER THORN}', u'\\TH')
+        self.register(u'\N{LATIN SMALL LETTER THORN}', u'\\th')
+        self.register(u'\N{LATIN CAPITAL LETTER D WITH DOT BELOW}', u'\\d D')
+        self.register(u'\N{LATIN SMALL LETTER D WITH DOT BELOW}', u'\\d d')
+        self.register(u'\N{LATIN CAPITAL LETTER L WITH DOT BELOW}', u'\\d L')
+        self.register(u'\N{LATIN SMALL LETTER L WITH DOT BELOW}', u'\\d l')
+        self.register(u'\N{LATIN CAPITAL LETTER M WITH DOT BELOW}', u'\\d M')
+        self.register(u'\N{LATIN SMALL LETTER M WITH DOT BELOW}', u'\\d m')
+        self.register(u'\N{LATIN CAPITAL LETTER N WITH DOT BELOW}', u'\\d N')
+        self.register(u'\N{LATIN SMALL LETTER N WITH DOT BELOW}', u'\\d n')
+        self.register(u'\N{LATIN CAPITAL LETTER R WITH DOT BELOW}', u'\\d R')
+        self.register(u'\N{LATIN SMALL LETTER R WITH DOT BELOW}', u'\\d r')
+        self.register(u'\N{LATIN CAPITAL LETTER S WITH DOT BELOW}', u'\\d S')
+        self.register(u'\N{LATIN SMALL LETTER S WITH DOT BELOW}', u'\\d s')
+        self.register(u'\N{LATIN CAPITAL LETTER T WITH DOT BELOW}', u'\\d T')
+        self.register(u'\N{LATIN SMALL LETTER T WITH DOT BELOW}', u'\\d t')
+        self.register(u'\N{PARTIAL DIFFERENTIAL}', u'\\partial', mode='math')
+        self.register(u'\N{N-ARY PRODUCT}', u'\\prod', mode='math')
+        self.register(u'\N{N-ARY SUMMATION}', u'\\sum', mode='math')
+        self.register(u'\N{SQUARE ROOT}', u'\\surd', mode='math')
+        self.register(u'\N{INFINITY}', u'\\infty', mode='math')
+        self.register(u'\N{INTEGRAL}', u'\\int', mode='math')
+        self.register(u'\N{INTERSECTION}', u'\\cap', mode='math')
+        self.register(u'\N{UNION}', u'\\cup', mode='math')
+        self.register(u'\N{RIGHTWARDS ARROW}', u'\\rightarrow', mode='math')
         self.register(
             u'\N{RIGHTWARDS DOUBLE ARROW}',
-            b'\\Rightarrow',
+            u'\\Rightarrow',
             mode='math')
-        self.register(u'\N{LEFTWARDS ARROW}', b'\\leftarrow', mode='math')
+        self.register(u'\N{LEFTWARDS ARROW}', u'\\leftarrow', mode='math')
         self.register(
             u'\N{LEFTWARDS DOUBLE ARROW}',
-            b'\\Leftarrow',
+            u'\\Leftarrow',
             mode='math')
-        self.register(u'\N{LOGICAL OR}', b'\\vee', mode='math')
-        self.register(u'\N{LOGICAL AND}', b'\\wedge', mode='math')
-        self.register(u'\N{ALMOST EQUAL TO}', b'\\approx', mode='math')
-        self.register(u'\N{NOT EQUAL TO}', b'\\neq', mode='math')
-        self.register(u'\N{LESS-THAN OR EQUAL TO}', b'\\leq', mode='math')
-        self.register(u'\N{GREATER-THAN OR EQUAL TO}', b'\\geq', mode='math')
-        self.register(u'\N{MODIFIER LETTER CIRCUMFLEX ACCENT}', b'\\^{}')
-        self.register(u'\N{CARON}', b'\\v{}')
-        self.register(u'\N{BREVE}', b'\\u{}')
-        self.register(u'\N{DOT ABOVE}', b'\\.{}')
-        self.register(u'\N{RING ABOVE}', b'\\r{}')
-        self.register(u'\N{OGONEK}', b'\\k{}')
-        self.register(u'\N{DOUBLE ACUTE ACCENT}', b'\\H{}')
-        self.register(u'\N{LATIN SMALL LIGATURE FI}', b'fi', decode=False)
-        self.register(u'\N{LATIN SMALL LIGATURE FL}', b'fl', decode=False)
-        self.register(u'\N{LATIN SMALL LIGATURE FF}', b'ff', decode=False)
+        self.register(u'\N{LOGICAL OR}', u'\\vee', mode='math')
+        self.register(u'\N{LOGICAL AND}', u'\\wedge', mode='math')
+        self.register(u'\N{ALMOST EQUAL TO}', u'\\approx', mode='math')
+        self.register(u'\N{NOT EQUAL TO}', u'\\neq', mode='math')
+        self.register(u'\N{LESS-THAN OR EQUAL TO}', u'\\leq', mode='math')
+        self.register(u'\N{GREATER-THAN OR EQUAL TO}', u'\\geq', mode='math')
+        self.register(u'\N{MODIFIER LETTER CIRCUMFLEX ACCENT}', u'\\^{}')
+        self.register(u'\N{CARON}', u'\\v{}')
+        self.register(u'\N{BREVE}', u'\\u{}')
+        self.register(u'\N{DOT ABOVE}', u'\\.{}')
+        self.register(u'\N{RING ABOVE}', u'\\r{}')
+        self.register(u'\N{OGONEK}', u'\\k{}')
+        self.register(u'\N{DOUBLE ACUTE ACCENT}', u'\\H{}')
+        self.register(u'\N{LATIN SMALL LIGATURE FI}', u'fi', decode=False)
+        self.register(u'\N{LATIN SMALL LIGATURE FL}', u'fl', decode=False)
+        self.register(u'\N{LATIN SMALL LIGATURE FF}', u'ff', decode=False)
 
-        self.register(u'\N{GREEK SMALL LETTER ALPHA}', b'\\alpha', mode='math')
-        self.register(u'\N{GREEK SMALL LETTER BETA}', b'\\beta', mode='math')
-        self.register(u'\N{GREEK SMALL LETTER GAMMA}', b'\\gamma', mode='math')
-        self.register(u'\N{GREEK SMALL LETTER DELTA}', b'\\delta', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER ALPHA}', u'\\alpha', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER BETA}', u'\\beta', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER GAMMA}', u'\\gamma', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER DELTA}', u'\\delta', mode='math')
         self.register(
             u'\N{GREEK SMALL LETTER EPSILON}',
-            b'\\epsilon',
+            u'\\epsilon',
             mode='math')
-        self.register(u'\N{GREEK SMALL LETTER ZETA}', b'\\zeta', mode='math')
-        self.register(u'\N{GREEK SMALL LETTER ETA}', b'\\eta', mode='math')
-        self.register(u'\N{GREEK SMALL LETTER THETA}', b'\\theta', mode='math')
-        self.register(u'\N{GREEK SMALL LETTER IOTA}', b'\\iota', mode='math')
-        self.register(u'\N{GREEK SMALL LETTER KAPPA}', b'\\kappa', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER ZETA}', u'\\zeta', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER ETA}', u'\\eta', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER THETA}', u'\\theta', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER IOTA}', u'\\iota', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER KAPPA}', u'\\kappa', mode='math')
         self.register(
             u'\N{GREEK SMALL LETTER LAMDA}',
-            b'\\lambda',
+            u'\\lambda',
             mode='math')  # LAMDA not LAMBDA
-        self.register(u'\N{GREEK SMALL LETTER MU}', b'\\mu', mode='math')
-        self.register(u'\N{GREEK SMALL LETTER NU}', b'\\nu', mode='math')
-        self.register(u'\N{GREEK SMALL LETTER XI}', b'\\xi', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER MU}', u'\\mu', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER NU}', u'\\nu', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER XI}', u'\\xi', mode='math')
         self.register(
             u'\N{GREEK SMALL LETTER OMICRON}',
-            b'\\omicron',
+            u'\\omicron',
             mode='math')
-        self.register(u'\N{GREEK SMALL LETTER PI}', b'\\pi', mode='math')
-        self.register(u'\N{GREEK SMALL LETTER RHO}', b'\\rho', mode='math')
-        self.register(u'\N{GREEK SMALL LETTER SIGMA}', b'\\sigma', mode='math')
-        self.register(u'\N{GREEK SMALL LETTER TAU}', b'\\tau', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER PI}', u'\\pi', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER RHO}', u'\\rho', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER SIGMA}', u'\\sigma', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER TAU}', u'\\tau', mode='math')
         self.register(
             u'\N{GREEK SMALL LETTER UPSILON}',
-            b'\\upsilon',
+            u'\\upsilon',
             mode='math')
-        self.register(u'\N{GREEK SMALL LETTER PHI}', b'\\phi', mode='math')
-        self.register(u'\N{GREEK PHI SYMBOL}', b'\\varphi', mode='math')
-        self.register(u'\N{GREEK SMALL LETTER CHI}', b'\\chi', mode='math')
-        self.register(u'\N{GREEK SMALL LETTER PSI}', b'\\psi', mode='math')
-        self.register(u'\N{GREEK SMALL LETTER OMEGA}', b'\\omega', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER PHI}', u'\\phi', mode='math')
+        self.register(u'\N{GREEK PHI SYMBOL}', u'\\varphi', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER CHI}', u'\\chi', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER PSI}', u'\\psi', mode='math')
+        self.register(u'\N{GREEK SMALL LETTER OMEGA}', u'\\omega', mode='math')
         self.register(
             u'\N{GREEK CAPITAL LETTER ALPHA}',
-            b'\\Alpha',
+            u'\\Alpha',
             mode='math')
-        self.register(u'\N{GREEK CAPITAL LETTER BETA}', b'\\Beta', mode='math')
+        self.register(u'\N{GREEK CAPITAL LETTER BETA}', u'\\Beta', mode='math')
         self.register(
             u'\N{GREEK CAPITAL LETTER GAMMA}',
-            b'\\Gamma',
+            u'\\Gamma',
             mode='math')
         self.register(
             u'\N{GREEK CAPITAL LETTER DELTA}',
-            b'\\Delta',
+            u'\\Delta',
             mode='math')
         self.register(
             u'\N{GREEK CAPITAL LETTER EPSILON}',
-            b'\\Epsilon',
+            u'\\Epsilon',
             mode='math')
-        self.register(u'\N{GREEK CAPITAL LETTER ZETA}', b'\\Zeta', mode='math')
-        self.register(u'\N{GREEK CAPITAL LETTER ETA}', b'\\Eta', mode='math')
+        self.register(u'\N{GREEK CAPITAL LETTER ZETA}', u'\\Zeta', mode='math')
+        self.register(u'\N{GREEK CAPITAL LETTER ETA}', u'\\Eta', mode='math')
         self.register(
             u'\N{GREEK CAPITAL LETTER THETA}',
-            b'\\Theta',
+            u'\\Theta',
             mode='math')
-        self.register(u'\N{GREEK CAPITAL LETTER IOTA}', b'\\Iota', mode='math')
+        self.register(u'\N{GREEK CAPITAL LETTER IOTA}', u'\\Iota', mode='math')
         self.register(
             u'\N{GREEK CAPITAL LETTER KAPPA}',
-            b'\\Kappa',
+            u'\\Kappa',
             mode='math')
         self.register(
             u'\N{GREEK CAPITAL LETTER LAMDA}',
-            b'\\Lambda',
+            u'\\Lambda',
             mode='math')  # LAMDA not LAMBDA
-        self.register(u'\N{GREEK CAPITAL LETTER MU}', b'\\Mu', mode='math')
-        self.register(u'\N{GREEK CAPITAL LETTER NU}', b'\\Nu', mode='math')
-        self.register(u'\N{GREEK CAPITAL LETTER XI}', b'\\Xi', mode='math')
+        self.register(u'\N{GREEK CAPITAL LETTER MU}', u'\\Mu', mode='math')
+        self.register(u'\N{GREEK CAPITAL LETTER NU}', u'\\Nu', mode='math')
+        self.register(u'\N{GREEK CAPITAL LETTER XI}', u'\\Xi', mode='math')
         self.register(
             u'\N{GREEK CAPITAL LETTER OMICRON}',
-            b'\\Omicron',
+            u'\\Omicron',
             mode='math')
-        self.register(u'\N{GREEK CAPITAL LETTER PI}', b'\\Pi', mode='math')
-        self.register(u'\N{GREEK CAPITAL LETTER RHO}', b'\\Rho', mode='math')
+        self.register(u'\N{GREEK CAPITAL LETTER PI}', u'\\Pi', mode='math')
+        self.register(u'\N{GREEK CAPITAL LETTER RHO}', u'\\Rho', mode='math')
         self.register(
             u'\N{GREEK CAPITAL LETTER SIGMA}',
-            b'\\Sigma',
+            u'\\Sigma',
             mode='math')
-        self.register(u'\N{GREEK CAPITAL LETTER TAU}', b'\\Tau', mode='math')
+        self.register(u'\N{GREEK CAPITAL LETTER TAU}', u'\\Tau', mode='math')
         self.register(
             u'\N{GREEK CAPITAL LETTER UPSILON}',
-            b'\\Upsilon',
+            u'\\Upsilon',
             mode='math')
-        self.register(u'\N{GREEK CAPITAL LETTER PHI}', b'\\Phi', mode='math')
-        self.register(u'\N{GREEK CAPITAL LETTER CHI}', b'\\Chi', mode='math')
-        self.register(u'\N{GREEK CAPITAL LETTER PSI}', b'\\Psi', mode='math')
+        self.register(u'\N{GREEK CAPITAL LETTER PHI}', u'\\Phi', mode='math')
+        self.register(u'\N{GREEK CAPITAL LETTER CHI}', u'\\Chi', mode='math')
+        self.register(u'\N{GREEK CAPITAL LETTER PSI}', u'\\Psi', mode='math')
         self.register(
             u'\N{GREEK CAPITAL LETTER OMEGA}',
-            b'\\Omega',
+            u'\\Omega',
             mode='math')
-        self.register(u'\N{COPYRIGHT SIGN}', b'\\copyright')
-        self.register(u'\N{COPYRIGHT SIGN}', b'\\textcopyright')
-        self.register(u'\N{LATIN CAPITAL LETTER A WITH ACUTE}', b"\\'A")
-        self.register(u'\N{LATIN CAPITAL LETTER I WITH ACUTE}', b"\\'I")
-        self.register(u'\N{HORIZONTAL ELLIPSIS}', b'\\ldots')
-        self.register(u'\N{TRADE MARK SIGN}', b'^{TM}', mode='math')
+        self.register(u'\N{COPYRIGHT SIGN}', u'\\copyright')
+        self.register(u'\N{COPYRIGHT SIGN}', u'\\textcopyright')
+        self.register(u'\N{LATIN CAPITAL LETTER A WITH ACUTE}', u"\\'A")
+        self.register(u'\N{LATIN CAPITAL LETTER I WITH ACUTE}', u"\\'I")
+        self.register(u'\N{HORIZONTAL ELLIPSIS}', u'\\ldots')
+        self.register(u'\N{TRADE MARK SIGN}', u'^{TM}', mode='math')
         self.register(
             u'\N{TRADE MARK SIGN}',
-            b'\\texttrademark',
+            u'\\texttrademark',
             package='textcomp')
         self.register(
             u'\N{REGISTERED SIGN}',
-            b'\\textregistered',
+            u'\\textregistered',
             package='textcomp')
         # \=O and \=o will be translated into Ō and ō before we can
         # match the full latex string... so decoding disabled for now
-        self.register(u'Ǭ', br'\textogonekcentered{\=O}', decode=False)
-        self.register(u'ǭ', br'\textogonekcentered{\=o}', decode=False)
-        self.register(u'ℕ', br'\mathbb{N}', mode='math')
-        self.register(u'ℕ', br'\mathbb N', mode='math', decode=False)
-        self.register(u'ℤ', br'\mathbb{Z}', mode='math')
-        self.register(u'ℤ', br'\mathbb Z', mode='math', decode=False)
-        self.register(u'ℚ', br'\mathbb{Q}', mode='math')
-        self.register(u'ℚ', br'\mathbb Q', mode='math', decode=False)
-        self.register(u'ℝ', br'\mathbb{R}', mode='math')
-        self.register(u'ℝ', br'\mathbb R', mode='math', decode=False)
-        self.register(u'ℂ', br'\mathbb{C}', mode='math')
-        self.register(u'ℂ', br'\mathbb C', mode='math', decode=False)
+        self.register(u'Ǭ', six.u(r'\textogonekcentered{\=O}'), decode=False)
+        self.register(u'ǭ', six.u(r'\textogonekcentered{\=o}'), decode=False)
+        self.register(u'ℕ', six.u(r'\mathbb{N}'), mode='math')
+        self.register(u'ℕ', six.u(r'\mathbb N'), mode='math', decode=False)
+        self.register(u'ℤ', six.u(r'\mathbb{Z}'), mode='math')
+        self.register(u'ℤ', six.u(r'\mathbb Z'), mode='math', decode=False)
+        self.register(u'ℚ', six.u(r'\mathbb{Q}'), mode='math')
+        self.register(u'ℚ', six.u(r'\mathbb Q'), mode='math', decode=False)
+        self.register(u'ℝ', six.u(r'\mathbb{R}'), mode='math')
+        self.register(u'ℝ', six.u(r'\mathbb R'), mode='math', decode=False)
+        self.register(u'ℂ', six.u(r'\mathbb{C}'), mode='math')
+        self.register(u'ℂ', six.u(r'\mathbb C'), mode='math', decode=False)
 
     def register(self, unicode_text, latex_text, mode='text', package=None,
                  decode=True, encode=True):
         """Register a correspondence between *unicode_text* and *latex_text*.
 
         :param str unicode_text: A unicode character.
-        :param bytes latex_text: Its corresponding LaTeX translation.
+        :param str latex_text: Its corresponding LaTeX translation.
         :param str mode: LaTeX mode in which the translation applies
             (``'text'`` or ``'math'``).
         :param str package: LaTeX package requirements (currently ignored).
@@ -616,15 +617,13 @@ class LatexUnicodeTable:
         """
         if mode == 'math':
             # also register text version
-            self.register(unicode_text, b'$' + latex_text + b'$', mode='text',
+            self.register(unicode_text, u'$' + latex_text + u'$', mode='text',
                           package=package, decode=decode, encode=encode)
             self.register(unicode_text,
-                          br'\(' + latex_text + br'\)', mode='text',
+                          six.u(r'\(') + latex_text + six.u(r'\)'), mode='text',
                           package=package, decode=decode, encode=encode)
             # XXX for the time being, we do not perform in-math substitutions
             return
-        if not self.lexer.binary_mode:
-            latex_text = latex_text.decode("ascii")
         if package is not None:
             # TODO implement packages
             pass
@@ -683,16 +682,16 @@ class LatexIncrementalEncoder(lexer.LatexIncrementalEncoder):
         if self.state == 'S':
             # in space eating mode
             # control space needed?
-            if bytes_.startswith(self.spacechar):
+            if bytes_.startswith(u' '):
                 # replace by control space
-                return self.controlspacechar, bytes_[1:]
+                return u'\\ ', bytes_[1:]
             else:
                 # insert space (it is eaten, but needed for separation)
-                return self.spacechar, bytes_
+                return u' ', bytes_
         else:
-            return self.emptychar, bytes_
+            return u'', bytes_
 
-    def _get_latex_bytes_tokens_from_char(self, c):
+    def _get_latex_chars_tokens_from_char(self, c):
         # if ascii, try latex equivalents
         # (this covers \, #, &, and other special LaTeX characters)
         if ord(c) < 128:
@@ -706,10 +705,7 @@ class LatexIncrementalEncoder(lexer.LatexIncrementalEncoder):
         except UnicodeEncodeError:
             pass
         else:
-            if self.binary_mode:
-                return bytes_, (lexer.Token(name='chars', text=bytes_),)
-            else:
-                return c, (lexer.Token(name='chars', text=c),)
+            return c, (lexer.Token(name='chars', text=c),)
         # next, try latex equivalents of common unicode characters
         try:
             return self.table.latex_map[c]
@@ -723,16 +719,13 @@ class LatexIncrementalEncoder(lexer.LatexIncrementalEncoder):
                     "don't know how to translate {0} into latex"
                     .format(repr(c)))
             elif self.errors == 'ignore':
-                return self.emptychar, (self.emptytoken,)
+                return u'', (self.emptytoken,)
             elif self.errors == 'replace':
                 # use the \\char command
                 # this assumes
                 # \usepackage[T1]{fontenc}
                 # \usepackage[utf8]{inputenc}
-                if self.binary_mode:
-                    bytes_ = b'{\\char' + str(ord(c)).encode("ascii") + b'}'
-                else:
-                    bytes_ = u'{\\char' + str(ord(c)) + u'}'
+                bytes_ = u'{\\char' + str(ord(c)) + u'}'
                 return bytes_, (lexer.Token(name='chars', text=bytes_),)
             elif self.errors == 'keep' and not self.binary_mode:
                 return c,  (lexer.Token(name='chars', text=c),)
@@ -741,14 +734,14 @@ class LatexIncrementalEncoder(lexer.LatexIncrementalEncoder):
                     "latex codec does not support {0} errors"
                     .format(self.errors))
 
-    def get_latex_bytes(self, unicode_, final=False):
+    def get_latex_chars(self, unicode_, final=False):
         if not isinstance(unicode_, string_types):
             raise TypeError(
                 "expected unicode for encode input, but got {0} instead"
                 .format(unicode_.__class__.__name__))
         # convert character by character
         for pos, c in enumerate(unicode_):
-            bytes_, tokens = self._get_latex_bytes_tokens_from_char(c)
+            bytes_, tokens = self._get_latex_chars_tokens_from_char(c)
             space, bytes_ = self.get_space_bytes(bytes_)
             # update state
             if tokens[-1].name == 'control_word':
@@ -783,8 +776,8 @@ class LatexIncrementalDecoder(lexer.LatexIncrementalDecoder):
     def setstate(self, state):
         raise NotImplementedError
 
-    def get_unicode_tokens(self, bytes_, final=False):
-        for token in self.get_tokens(bytes_, final=final):
+    def get_unicode_tokens(self, chars, final=False):
+        for token in self.get_tokens(chars, final=final):
             # at this point, token_buffer does not match anything
             self.token_buffer.append(token)
             # new token appended at the end, see if we have a match now

--- a/latexcodec/codec.py
+++ b/latexcodec/codec.py
@@ -62,7 +62,7 @@ from __future__ import print_function
 
 import codecs
 import six
-from six import string_types
+from six import string_types, text_type
 from six.moves import range
 
 from latexcodec import lexer
@@ -588,18 +588,18 @@ class LatexUnicodeTable:
             package='textcomp')
         # \=O and \=o will be translated into Ō and ō before we can
         # match the full latex string... so decoding disabled for now
-        self.register(u'Ǭ', six.u(r'\textogonekcentered{\=O}'), decode=False)
-        self.register(u'ǭ', six.u(r'\textogonekcentered{\=o}'), decode=False)
-        self.register(u'ℕ', six.u(r'\mathbb{N}'), mode='math')
-        self.register(u'ℕ', six.u(r'\mathbb N'), mode='math', decode=False)
-        self.register(u'ℤ', six.u(r'\mathbb{Z}'), mode='math')
-        self.register(u'ℤ', six.u(r'\mathbb Z'), mode='math', decode=False)
-        self.register(u'ℚ', six.u(r'\mathbb{Q}'), mode='math')
-        self.register(u'ℚ', six.u(r'\mathbb Q'), mode='math', decode=False)
-        self.register(u'ℝ', six.u(r'\mathbb{R}'), mode='math')
-        self.register(u'ℝ', six.u(r'\mathbb R'), mode='math', decode=False)
-        self.register(u'ℂ', six.u(r'\mathbb{C}'), mode='math')
-        self.register(u'ℂ', six.u(r'\mathbb C'), mode='math', decode=False)
+        self.register(u'Ǭ', text_type(r'\textogonekcentered{\=O}'), decode=False)
+        self.register(u'ǭ', text_type(r'\textogonekcentered{\=o}'), decode=False)
+        self.register(u'ℕ', text_type(r'\mathbb{N}'), mode='math')
+        self.register(u'ℕ', text_type(r'\mathbb N'), mode='math', decode=False)
+        self.register(u'ℤ', text_type(r'\mathbb{Z}'), mode='math')
+        self.register(u'ℤ', text_type(r'\mathbb Z'), mode='math', decode=False)
+        self.register(u'ℚ', text_type(r'\mathbb{Q}'), mode='math')
+        self.register(u'ℚ', text_type(r'\mathbb Q'), mode='math', decode=False)
+        self.register(u'ℝ', text_type(r'\mathbb{R}'), mode='math')
+        self.register(u'ℝ', text_type(r'\mathbb R'), mode='math', decode=False)
+        self.register(u'ℂ', text_type(r'\mathbb{C}'), mode='math')
+        self.register(u'ℂ', text_type(r'\mathbb C'), mode='math', decode=False)
 
     def register(self, unicode_text, latex_text, mode='text', package=None,
                  decode=True, encode=True):
@@ -620,7 +620,7 @@ class LatexUnicodeTable:
             self.register(unicode_text, u'$' + latex_text + u'$', mode='text',
                           package=package, decode=decode, encode=encode)
             self.register(unicode_text,
-                          six.u(r'\(') + latex_text + six.u(r'\)'), mode='text',
+                          text_type(r'\(') + latex_text + text_type(r'\)'), mode='text',
                           package=package, decode=decode, encode=encode)
             # XXX for the time being, we do not perform in-math substitutions
             return

--- a/latexcodec/lexer.py
+++ b/latexcodec/lexer.py
@@ -65,27 +65,7 @@ Token = collections.namedtuple("Token", "name text")
 # class serves excellently as a base class for incremental decoders,
 # but of course we don't decode yet until later
 
-
-class MetaLatexCoder(type):
-
-    def __init__(cls, name, bases, dct):
-        super(MetaLatexCoder, cls).__init__(name, bases, dct)
-        cls.emptytoken = Token(u"unknown", cls._fixit(b""))
-        cls.partoken = Token("control_word", cls._fixit(b"\\par"))
-        cls.spacetoken = Token("space", cls._fixit(b" "))
-        cls.replacetoken = Token(
-            "chars", b"?" if cls.binary_mode else u"\ufffd")
-        cls.curlylefttoken = Token("chars", cls._fixit(b"{"))
-        cls.curlyrighttoken = Token("chars", cls._fixit(b"}"))
-        cls.emptychar = cls._fixit(b"")
-        cls.spacechar = cls._fixit(b" ")
-        cls.controlspacechar = cls._fixit(b"\\ ")
-
-    def _fixit(cls, bytes_):
-        return bytes_ if cls.binary_mode else bytes_.decode("ascii")
-
-
-class MetaRegexpLexer(MetaLatexCoder):
+class MetaRegexpLexer(type):
 
     """Metaclass for :class:`RegexpLexer`. Compiles tokens into a
     regular expression.
@@ -93,8 +73,8 @@ class MetaRegexpLexer(MetaLatexCoder):
 
     def __init__(cls, name, bases, dct):
         super(MetaRegexpLexer, cls).__init__(name, bases, dct)
-        regexp_string = cls._fixit(b"|".join(
-            b"(?P<" + name.encode("ascii") + b">" + regexp + b")"
+        regexp_string = ("|".join(
+            "(?P<" + name + ">" + regexp + ")"
             for name, regexp in cls.tokens))
         cls.regexp = re.compile(regexp_string, re.DOTALL)
 
@@ -104,13 +84,10 @@ class RegexpLexer(codecs.IncrementalDecoder):
 
     """Abstract base class for regexp based lexers."""
 
+    emptytoken = Token(u"unknown", u"")
+    
     tokens = ()
     """Tuple containing all token regular expressions."""
-
-    binary_mode = True
-    """Whether this lexer processes binary data (bytes) or text data
-    (unicode).
-    """
 
     def __init__(self, errors='strict'):
         """Initialize the codec."""
@@ -132,7 +109,7 @@ class RegexpLexer(codecs.IncrementalDecoder):
         """
         self.raw_buffer = Token('unknown', state[0])
 
-    def get_raw_tokens(self, bytes_, final=False):
+    def get_raw_tokens(self, chars, final=False):
         """Yield tokens without any further processing. Tokens are one of:
 
         - ``\\<word>``: a control word (i.e. a command)
@@ -141,9 +118,9 @@ class RegexpLexer(codecs.IncrementalDecoder):
         - a series of byte characters
         """
         if self.raw_buffer.text:
-            bytes_ = self.raw_buffer.text + bytes_
+            chars = self.raw_buffer.text + chars
         self.raw_buffer = self.emptytoken
-        for match in self.regexp.finditer(bytes_):
+        for match in self.regexp.finditer(chars):
             # yield the buffer token
             if self.raw_buffer.text:
                 yield self.raw_buffer
@@ -164,47 +141,50 @@ class LatexLexer(RegexpLexer):
 
     """A very simple lexer for tex/latex bytes."""
 
+    partoken = Token("control_word", u"\\par")
+    spacetoken = Token("space", u" ")
+    replacetoken = Token("chars", u"\ufffd")
+    curlylefttoken = Token("chars", u"{")
+    curlyrighttoken = Token("chars", u"}")
+        
     # implementation note: every token **must** be decodable by inputenc
     tokens = (
         # comment: for ease, and for speed, we handle it as a token
-        (u'comment', br'(?<![\\])%[^\n]*'),
+        (u'comment', r'(?<![\\])%[^\n]*'),
         # control tokens
         # in latex, some control tokens skip following whitespace
         # ('control-word' and 'control-symbol')
         # others do not ('control-symbol-x')
         # XXX TBT says no control symbols skip whitespace (except '\ ')
         # XXX but tests reveal otherwise?
-        (u'control_word', br'[\\][a-zA-Z]+'),
-        (u'control_symbol', br'[\\][~' br"'" br'"` =^!.]'),
+        (u'control_word', r'[\\][a-zA-Z]+'),
+        (u'control_symbol', r'[\\][~' r"'" r'"` =^!.]'),
         # TODO should only match ascii
-        (u'control_symbol_x', br'[\\][^a-zA-Z]'),
+        (u'control_symbol_x', r'[\\][^a-zA-Z]'),
         # parameter tokens
-        # also support a lone hash so we can lex things like b'#a'
-        (u'parameter', br'\#[0-9]|\#'),
+        # also support a lone hash so we can lex things like '#a'
+        (u'parameter', r'\#[0-9]|\#'),
         # any remaining characters; for ease we also handle space and
         # newline as tokens
         # XXX TBT does not mention \t to be a space character as well
         # XXX but tests reveal otherwise?
-        (u'space', br' |\t'),
-        (u'newline', br'\n'),
-        (u'mathshift', br'[$][$]|[$]'),
+        (u'space', r' |\t'),
+        (u'newline', r'\n'),
+        (u'mathshift', r'[$][$]|[$]'),
         # note: some chars joined together to make it easier to detect
         # symbols that have a special function (i.e. --, ---, etc.)
         (u'chars',
-         br'---|--|-|[`][`]'
-         br"|['][']"
-         br'|[?][`]|[!][`]'
+         r'---|--|-|[`][`]'
+         r"|['][']"
+         r'|[?][`]|[!][`]'
          # separate chars because brackets are optional
          # e.g. fran\\c cais = fran\\c{c}ais in latex
          # so only way to detect \\c acting on c only is this way
-         br'|(?![ %#$\n\t\\])' b'[\x00-\x7f]'
-         # we have to join everything else together to support
-         # multibyte encodings: every token must be decodable!!
-         b'|[^\x00-\x7f]+'),
+         r'|(?![ %#$\n\t\\]).'),
         # trailing garbage which we cannot decode otherwise
         # (such as a lone '\' at the end of a buffer)
         # is never emitted, but used internally by the buffer
-        (u'unknown', br'.'),
+        (u'unknown', r'.'),
     )
     """List of token names, and the regular expressions they match."""
 
@@ -219,7 +199,7 @@ class LatexIncrementalLexer(LatexLexer):
     * no newline characters: paragraphs are separated by '\\par'
     * spaces following control tokens are compressed
     """
-
+    
     def reset(self):
         super(LatexIncrementalLexer, self).reset()
         # three possible states:
@@ -241,16 +221,16 @@ class LatexIncrementalLexer(LatexLexer):
         self.state = {0: 'M', 1: 'N', 2: 'S'}[state[1] & 3]
         self.inline_math = bool(state[1] & 4)
 
-    def get_tokens(self, bytes_, final=False):
+    def get_tokens(self, chars, final=False):
         """Yield tokens while maintaining a state. Also skip
         whitespace after control words and (some) control symbols.
         Replaces newlines by spaces and \\par commands depending on
         the context.
         """
-        # current position relative to the start of bytes_ in the sequence
+        # current position relative to the start of chars in the sequence
         # of bytes that have been decoded
         pos = -len(self.raw_buffer.text)
-        for token in self.get_raw_tokens(bytes_, final=final):
+        for token in self.get_raw_tokens(chars, final=final):
             pos = pos + len(token.text)
             assert pos >= 0  # first token includes at least self.raw_buffer
             if token.name == 'newline':
@@ -310,15 +290,11 @@ class LatexIncrementalLexer(LatexLexer):
                 yield token
             elif token.name == 'unknown':
                 if self.errors == 'strict':
-                    # hack around a bug in Python: UnicodeDecodeError
-                    # expects binary input
-                    if not self.binary_mode:
-                        bytes_ = bytes_.encode("utf8")
-                    # current position within bytes_
+                    # current position within chars
                     # this is the position right after the unknown token
                     raise UnicodeDecodeError(
                         "latex",  # codec
-                        bytes_,  # problematic input
+                        chars.encode('utf8'),  # problematic input
                         pos - len(token.text),  # start of problematic token
                         pos,  # end of it
                         "unknown token {0!r}".format(token.text))
@@ -347,8 +323,17 @@ class LatexIncrementalDecoder(LatexIncrementalLexer):
     inputenc = "ascii"
     """Input encoding. **Must** extend ascii."""
 
+    binary_mode = True
+    """Whether this lexer processes binary data (bytes) or text data
+    (unicode).
+    """
+
+    def __init__(self, errors='strict'):
+        super(LatexIncrementalDecoder, self).__init__(errors)
+        self.decoder = codecs.getincrementaldecoder(self.inputenc)(errors=errors)
+    
     def decode_token(self, token):
-        """Returns the decoded token text in :attr:`inputenc` encoding.
+        """Returns the decoded token text.
 
         .. note::
 
@@ -363,20 +348,15 @@ class LatexIncrementalDecoder(LatexIncrementalLexer):
            ``u'\\helloworld'``.
 
         """
-        # in python 3, the token text can be a memoryview
-        # which do not have a decode method; must cast to bytes explicitly
-        if self.binary_mode:
-            text = binary_type(token.text).decode(self.inputenc)
-        else:
-            text = token.text
+        text = token.text
         return text if token.name != 'control_word' else text + u' '
 
-    def get_unicode_tokens(self, bytes_, final=False):
-        """Decode every token in :attr:`inputenc` encoding. Override to
+    def get_unicode_tokens(self, chars, final=False):
+        """Decode every token. Override to
         process the tokens in some other way (for example, for token
         translation).
         """
-        for token in self.get_tokens(bytes_, final=final):
+        for token in self.get_tokens(chars, final=final):
             yield self.decode_token(token)
 
     def decode(self, bytes_, final=False):
@@ -385,15 +365,20 @@ class LatexIncrementalDecoder(LatexIncrementalLexer):
         This implementation calls :meth:`get_unicode_tokens` and joins
         the resulting unicode strings together.
         """
-        try:
-            return u''.join(self.get_unicode_tokens(bytes_, final=final))
-        except UnicodeDecodeError as e:
-            # API requires that the encode method raises a ValueError
-            # in this case
-            raise ValueError(e)
+        if self.binary_mode:
+            try:
+                # in python 3, the token text can be a memoryview
+                # which do not have a decode method; must cast to bytes explicitly
+                chars = self.decoder.decode(binary_type(bytes_), final=final)
+            except UnicodeDecodeError as e:
+                # API requires that the encode method raises a ValueError
+                # in this case
+                raise ValueError(e)
+        else:
+            chars = bytes_
+        return u''.join(self.get_unicode_tokens(chars, final=final))
 
 
-@add_metaclass(MetaLatexCoder)
 class LatexIncrementalEncoder(codecs.IncrementalEncoder):
 
     """Simple incremental encoder for LaTeX. Transforms unicode into
@@ -403,14 +388,16 @@ class LatexIncrementalEncoder(codecs.IncrementalEncoder):
     :meth:`get_latex_bytes`.
     """
 
+    emptytoken = Token(u"unknown", u"")
+    
     inputenc = "ascii"
     """Input encoding. **Must** extend ascii."""
 
     binary_mode = True
-    """Whether this encoder processes binary data (bytes) or text data
+    """Whether this lexer processes binary data (bytes) or text data
     (unicode).
     """
-
+    
     def __init__(self, errors='strict'):
         """Initialize the codec."""
         self.errors = errors
@@ -454,31 +441,30 @@ class LatexIncrementalEncoder(codecs.IncrementalEncoder):
             yield self.buffer
             self.buffer = u""
 
-    def get_latex_bytes(self, unicode_, final=False):
-        """Encode every character in :attr:`inputenc` encoding. Override to
+    def get_latex_chars(self, unicode_, final=False):
+        """Encode every character. Override to
         process the unicode in some other way (for example, for character
         translation).
         """
-        if self.binary_mode:
-            for token in self.get_unicode_tokens(unicode_, final=final):
-                yield token.encode(self.inputenc, self.errors)
-        else:
-            for token in self.get_unicode_tokens(unicode_, final=final):
-                yield token
+        for token in self.get_unicode_tokens(unicode_, final=final):
+            yield token
 
     def encode(self, unicode_, final=False):
         """Encode the *unicode_* string into LaTeX :class:`bytes`.
 
-        This implementation calls :meth:`get_latex_bytes` and joins
+        This implementation calls :meth:`get_latex_chars` and joins
         the resulting :class:`bytes` together.
         """
-        try:
-            return self.emptychar.join(
-                self.get_latex_bytes(unicode_, final=final))
-        except UnicodeEncodeError as e:
-            # API requires that the encode method raises a ValueError
-            # in this case
-            raise ValueError(e)
+        chars = u''.join(self.get_latex_chars(unicode_, final=final))
+        if self.binary_mode:
+            try:
+                return chars.encode(self.inputenc, self.errors)
+            except UnicodeEncodeError as e:
+                # API requires that the encode method raises a ValueError
+                # in this case
+                raise ValueError(e)
+        else:
+            return chars
 
 
 class UnicodeLatexLexer(LatexLexer):

--- a/latexcodec/lexer.py
+++ b/latexcodec/lexer.py
@@ -85,7 +85,7 @@ class RegexpLexer(codecs.IncrementalDecoder):
     """Abstract base class for regexp based lexers."""
 
     emptytoken = Token(u"unknown", u"")
-    
+
     tokens = ()
     """Tuple containing all token regular expressions."""
 
@@ -146,7 +146,7 @@ class LatexLexer(RegexpLexer):
     replacetoken = Token("chars", u"\ufffd")
     curlylefttoken = Token("chars", u"{")
     curlyrighttoken = Token("chars", u"}")
-        
+
     # implementation note: every token **must** be decodable by inputenc
     tokens = (
         # comment: for ease, and for speed, we handle it as a token
@@ -199,7 +199,7 @@ class LatexIncrementalLexer(LatexLexer):
     * no newline characters: paragraphs are separated by '\\par'
     * spaces following control tokens are compressed
     """
-    
+
     def reset(self):
         super(LatexIncrementalLexer, self).reset()
         # three possible states:
@@ -330,8 +330,8 @@ class LatexIncrementalDecoder(LatexIncrementalLexer):
 
     def __init__(self, errors='strict'):
         super(LatexIncrementalDecoder, self).__init__(errors)
-        self.decoder = codecs.getincrementaldecoder(self.inputenc)(errors=errors)
-    
+        self.decoder = codecs.getincrementaldecoder(self.inputenc)(errors)
+
     def decode_token(self, token):
         """Returns the decoded token text.
 
@@ -368,7 +368,8 @@ class LatexIncrementalDecoder(LatexIncrementalLexer):
         if self.binary_mode:
             try:
                 # in python 3, the token text can be a memoryview
-                # which do not have a decode method; must cast to bytes explicitly
+                # which do not have a decode method; must cast to
+                # bytes explicitly
                 chars = self.decoder.decode(binary_type(bytes_), final=final)
             except UnicodeDecodeError as e:
                 # API requires that the encode method raises a ValueError
@@ -389,7 +390,7 @@ class LatexIncrementalEncoder(codecs.IncrementalEncoder):
     """
 
     emptytoken = Token(u"unknown", u"")
-    
+
     inputenc = "ascii"
     """Input encoding. **Must** extend ascii."""
 
@@ -397,7 +398,7 @@ class LatexIncrementalEncoder(codecs.IncrementalEncoder):
     """Whether this lexer processes binary data (bytes) or text data
     (unicode).
     """
-    
+
     def __init__(self, errors='strict'):
         """Initialize the codec."""
         self.errors = errors

--- a/test/test_latex_codec.py
+++ b/test/test_latex_codec.py
@@ -221,7 +221,10 @@ class TestDecoder(TestCase):
     def test_double_quotes_unicode(self):
         self.decode(u"“á”", u"``á''".encode("utf8"), "utf8")
 
+    def test_double_quotes_gb2312(self):
+        self.decode(u"“你好”", u"``你好''".encode('gb2312'), 'gb2312')
 
+        
 class TestStreamDecoder(TestDecoder):
 
     """Stream decoder tests."""

--- a/test/test_latex_codec.py
+++ b/test/test_latex_codec.py
@@ -224,7 +224,7 @@ class TestDecoder(TestCase):
     def test_double_quotes_gb2312(self):
         self.decode(u"“你好”", u"``你好''".encode('gb2312'), 'gb2312')
 
-        
+
 class TestStreamDecoder(TestDecoder):
 
     """Stream decoder tests."""

--- a/test/test_latex_lexer.py
+++ b/test/test_latex_lexer.py
@@ -4,6 +4,7 @@
 
 import nose.tools
 from unittest import TestCase
+import six
 
 from latexcodec.lexer import (
     LatexLexer, UnicodeLatexLexer,
@@ -15,39 +16,39 @@ from latexcodec.lexer import (
 
 class MockLexer(LatexLexer):
     tokens = (
-        (u'chars', br'mock'),
-        (u'unknown', br'.'),
+        ('chars', u'mock'),
+        ('unknown', u'.'),
         )
 
 
 class MockIncrementalDecoder(LatexIncrementalDecoder):
     tokens = (
-        (u'chars', br'mock'),
-        (u'unknown', br'.'),
+        ('chars', u'mock'),
+        ('unknown', u'.'),
         )
 
 
 def test_token_create_with_args():
-    t = Token('hello', b'world')
+    t = Token('hello', u'world')
     nose.tools.assert_equal(t.name, 'hello')
-    nose.tools.assert_equal(t.text, b'world')
+    nose.tools.assert_equal(t.text, u'world')
 
 
 @nose.tools.raises(AttributeError)
 def test_token_assign_name():
-    t = Token('hello', b'world')
+    t = Token('hello', u'world')
     t.name = 'test'
 
 
 @nose.tools.raises(AttributeError)
 def test_token_assign_text():
-    t = Token('hello', b'world')
+    t = Token('hello', u'world')
     t.text = 'test'
 
 
 @nose.tools.raises(AttributeError)
 def test_token_assign_other():
-    t = Token('hello', b'world')
+    t = Token('hello', u'world')
     t.blabla = 'test'
 
 
@@ -60,9 +61,6 @@ class BaseLatexLexerTest(TestCase):
         self.lexer = self.Lexer(errors=self.errors)
 
     def lex_it(self, latex_code, latex_tokens, final=False):
-        if not self.lexer.binary_mode:
-            latex_code = latex_code.decode("ascii")
-            latex_tokens = [token.decode("ascii") for token in latex_tokens]
         tokens = self.lexer.get_raw_tokens(latex_code, final=final)
         self.assertEqual(
             list(token.text for token in tokens),
@@ -77,87 +75,87 @@ class LatexLexerTest(BaseLatexLexerTest):
     Lexer = LatexLexer
 
     def test_null(self):
-        self.lex_it(b'', [], final=True)
+        self.lex_it('', [], final=True)
 
     def test_hello(self):
         self.lex_it(
-            b'hello!  [#1] This \\is\\   \\^ a \ntest.\n'
-            b'    \nHey.\n\n\\# x \\#x',
-            br'h|e|l|l|o|!| | |[|#1|]| |T|h|i|s| |\is|\ | | |\^| |a| '
-            b'|\n|t|e|s|t|.|\n| | | | |\n|H|e|y|.|\n|\n'
-            br'|\#| |x| |\#|x'.split(b'|'),
+            u'hello!  [#1] This \\is\\   \\^ a \ntest.\n'
+            u'    \nHey.\n\n\\# x \\#x',
+            six.u(r'h|e|l|l|o|!| | |[|#1|]| |T|h|i|s| |\is|\ | | |\^| |a| '
+                  '|\n|t|e|s|t|.|\n| | | | |\n|H|e|y|.|\n|\n'
+                  r'|\#| |x| |\#|x').split(u'|'),
             final=True
         )
 
     def test_comment(self):
         self.lex_it(
-            b'test% some comment\ntest',
-            b't|e|s|t|% some comment|\n|t|e|s|t'.split(b'|'),
+            u'test% some comment\ntest',
+            u't|e|s|t|% some comment|\n|t|e|s|t'.split(u'|'),
             final=True
         )
 
     def test_comment_newline(self):
         self.lex_it(
-            b'test% some comment\n\ntest',
-            b't|e|s|t|% some comment|\n|\n|t|e|s|t'.split(b'|'),
+            u'test% some comment\n\ntest',
+            u't|e|s|t|% some comment|\n|\n|t|e|s|t'.split(u'|'),
             final=True
         )
 
     def test_control(self):
         self.lex_it(
-            b'\\hello\\world',
-            b'\\hello|\\world'.split(b'|'),
+            u'\\hello\\world',
+            u'\\hello|\\world'.split(u'|'),
             final=True
         )
 
     def test_control_whitespace(self):
         self.lex_it(
-            b'\\hello   \\world   ',
-            b'\\hello| | | |\\world| | | '.split(b'|'),
+            u'\\hello   \\world   ',
+            u'\\hello| | | |\\world| | | '.split(u'|'),
             final=True
         )
 
     def test_controlx(self):
         self.lex_it(
-            b'\\#\\&',
-            b'\\#|\\&'.split(b'|'),
+            u'\\#\\&',
+            u'\\#|\\&'.split(u'|'),
             final=True
         )
 
     def test_controlx_whitespace(self):
         self.lex_it(
-            b'\\#    \\&   ',
-            b'\\#| | | | |\\&| | | '.split(b'|'),
+            u'\\#    \\&   ',
+            u'\\#| | | | |\\&| | | '.split(u'|'),
             final=True
         )
 
     def test_buffer(self):
         self.lex_it(
-            b'hi\\t',
-            b'h|i'.split(b'|'),
+            u'hi\\t',
+            u'h|i'.split(u'|'),
         )
         self.lex_it(
-            b'here',
-            [b'\\there'],
+            'here',
+            [u'\\there'],
             final=True,
         )
 
     def test_state(self):
         self.lex_it(
-            b'hi\\t',
-            b'h|i'.split(b'|'),
+            u'hi\\t',
+            u'h|i'.split(u'|'),
         )
         state = self.lexer.getstate()
         self.lexer.reset()
         self.lex_it(
-            b'here',
-            b'h|e|r|e'.split(b'|'),
+            u'here',
+            u'h|e|r|e'.split(u'|'),
             final=True,
         )
         self.lexer.setstate(state)
         self.lex_it(
-            b'here',
-            [b'\\there'],
+            u'here',
+            [u'\\there'],
             final=True,
         )
 
@@ -167,35 +165,35 @@ class LatexLexerTest(BaseLatexLexerTest):
 
     def test_final_backslash(self):
         self.lex_it(
-            b'notsogood\\',
-            b'n|o|t|s|o|g|o|o|d|\\'.split(b'|'),
+            u'notsogood\\',
+            u'n|o|t|s|o|g|o|o|d|\\'.split(u'|'),
             final=True
         )
 
     def test_final_comment(self):
         self.lex_it(
-            b'hello%',
-            b'h|e|l|l|o|%'.split(b'|'),
+            u'hello%',
+            u'h|e|l|l|o|%'.split(u'|'),
             final=True
         )
 
     def test_hash(self):
-        self.lex_it(b'#', [b'#'], final=True)
+        self.lex_it(u'#', [u'#'], final=True)
 
     def test_tab(self):
-        self.lex_it(b'\\c\tc', b'\\c|\t|c'.split(b'|'), final=True)
+        self.lex_it(u'\\c\tc', u'\\c|\t|c'.split(u'|'), final=True)
 
     def test_percent(self):
-        self.lex_it(b'This is a \\% test.',
-                    b'T|h|i|s| |i|s| |a| |\\%| |t|e|s|t|.'.split(b'|'),
+        self.lex_it(u'This is a \\% test.',
+                    u'T|h|i|s| |i|s| |a| |\\%| |t|e|s|t|.'.split(u'|'),
                     final=True)
-        self.lex_it(b'\\% %test',
-                    b'\\%| |%test'.split(b'|'), final=True)
-        self.lex_it(b'\\% %test\nhi',
-                    b'\\%| |%test|\n|h|i'.split(b'|'), final=True)
+        self.lex_it(u'\\% %test',
+                    u'\\%| |%test'.split(u'|'), final=True)
+        self.lex_it(u'\\% %test\nhi',
+                    u'\\%| |%test|\n|h|i'.split(u'|'), final=True)
 
     def test_double_quotes(self):
-        self.lex_it(b"``a+b''", b"``|a|+|b|''".split(b'|'), final=True)
+        self.lex_it(u"``a+b''", u"``|a|+|b|''".split(u'|'), final=True)
 
 
 class UnicodeLatexLexerTest(LatexLexerTest):
@@ -216,8 +214,6 @@ class BaseLatexIncrementalDecoderTest(TestCase):
         return s if self.lexer.binary_mode else s.decode("ascii")
 
     def lex_it(self, latex_code, latex_tokens, final=False):
-        latex_code = self.fix(latex_code)
-        latex_tokens = [self.fix(token) for token in latex_tokens]
         tokens = self.lexer.get_tokens(latex_code, final=final)
         self.assertEqual(
             list(token.text for token in tokens),
@@ -232,68 +228,68 @@ class LatexIncrementalDecoderTest(BaseLatexIncrementalDecoderTest):
     IncrementalDecoder = LatexIncrementalDecoder
 
     def test_null(self):
-        self.lex_it(b'', [], final=True)
+        self.lex_it(u'', [], final=True)
 
     def test_hello(self):
         self.lex_it(
-            b'hello!  [#1] This \\is\\   \\^ a \ntest.\n'
-            b'    \nHey.\n\n\\# x \\#x',
-            br'h|e|l|l|o|!| |[|#1|]| |T|h|i|s| |\is|\ |\^|a| '
-            br'|t|e|s|t|.| |\par|H|e|y|.| '
-            br'|\par|\#| |x| |\#|x'.split(b'|'),
+            u'hello!  [#1] This \\is\\   \\^ a \ntest.\n'
+            u'    \nHey.\n\n\\# x \\#x',
+            six.u(r'h|e|l|l|o|!| |[|#1|]| |T|h|i|s| |\is|\ |\^|a| '
+                  r'|t|e|s|t|.| |\par|H|e|y|.| '
+                  r'|\par|\#| |x| |\#|x').split(u'|'),
             final=True
         )
 
     def test_comment(self):
         self.lex_it(
-            b'test% some comment\ntest',
-            b't|e|s|t|t|e|s|t'.split(b'|'),
+            u'test% some comment\ntest',
+            u't|e|s|t|t|e|s|t'.split(u'|'),
             final=True
         )
 
     def test_comment_newline(self):
         self.lex_it(
-            b'test% some comment\n\ntest',
-            b't|e|s|t|\\par|t|e|s|t'.split(b'|'),
+            u'test% some comment\n\ntest',
+            u't|e|s|t|\\par|t|e|s|t'.split(u'|'),
             final=True
         )
 
     def test_control(self):
         self.lex_it(
-            b'\\hello\\world',
-            b'\\hello|\\world'.split(b'|'),
+            u'\\hello\\world',
+            u'\\hello|\\world'.split(u'|'),
             final=True
         )
 
     def test_control_whitespace(self):
         self.lex_it(
-            b'\\hello   \\world   ',
-            b'\\hello|\\world'.split(b'|'),
+            u'\\hello   \\world   ',
+            u'\\hello|\\world'.split(u'|'),
             final=True
         )
 
     def test_controlx(self):
         self.lex_it(
-            b'\\#\\&',
-            b'\\#|\\&'.split(b'|'),
+            u'\\#\\&',
+            u'\\#|\\&'.split(u'|'),
             final=True
         )
 
     def test_controlx_whitespace(self):
         self.lex_it(
-            b'\\#    \\&   ',
-            b'\\#| |\\&| '.split(b'|'),
+            u'\\#    \\&   ',
+            u'\\#| |\\&| '.split(u'|'),
             final=True
         )
 
     def test_buffer(self):
         self.lex_it(
-            b'hi\\t',
-            b'h|i'.split(b'|'),
+            u'hi\\t',
+            u'h|i'.split(u'|'),
         )
         self.lex_it(
-            b'here',
-            [b'\\there'],
+            u'here',
+            [u'\\there'],
             final=True,
         )
 
@@ -314,41 +310,41 @@ class LatexIncrementalDecoderTest(BaseLatexIncrementalDecoderTest):
 
     def test_state_middle(self):
         self.lex_it(
-            b'hi\\t',
-            b'h|i'.split(b'|'),
+            u'hi\\t',
+            u'h|i'.split(u'|'),
         )
         state = self.lexer.getstate()
         self.assertEqual(self.lexer.state, 'M')
         self.assertEqual(self.lexer.raw_buffer.name, 'control_word')
-        self.assertEqual(self.lexer.raw_buffer.text, self.fix(b'\\t'))
+        self.assertEqual(self.lexer.raw_buffer.text, u'\\t')
         self.lexer.reset()
         self.assertEqual(self.lexer.state, 'N')
         self.assertEqual(self.lexer.raw_buffer.name, 'unknown')
-        self.assertEqual(self.lexer.raw_buffer.text, self.fix(b''))
+        self.assertEqual(self.lexer.raw_buffer.text, u'')
         self.lex_it(
-            b'here',
-            b'h|e|r|e'.split(b'|'),
+            u'here',
+            u'h|e|r|e'.split(u'|'),
             final=True,
         )
         self.lexer.setstate(state)
         self.assertEqual(self.lexer.state, 'M')
         self.assertEqual(self.lexer.raw_buffer.name, 'control_word')
-        self.assertEqual(self.lexer.raw_buffer.text, self.fix(b'\\t'))
+        self.assertEqual(self.lexer.raw_buffer.text, u'\\t')
         self.lex_it(
-            b'here',
-            [b'\\there'],
+            u'here',
+            [u'\\there'],
             final=True,
         )
 
     def test_state_inline_math(self):
         self.lex_it(
-            b'hi$t',
-            b'h|i|$'.split(b'|'),
+            u'hi$t',
+            u'h|i|$'.split(u'|'),
         )
         assert self.lexer.inline_math
         self.lex_it(
-            b'here$',
-            b't|h|e|r|e|$'.split(b'|'),
+            u'here$',
+            u't|h|e|r|e|$'.split(u'|'),
             final=True,
         )
         assert not self.lexer.inline_math
@@ -357,23 +353,23 @@ class LatexIncrementalDecoderTest(BaseLatexIncrementalDecoderTest):
     @nose.tools.raises(UnicodeDecodeError)
     def test_final_backslash(self):
         self.lex_it(
-            b'notsogood\\',
-            [b'notsogood'],
+            u'notsogood\\',
+            [u'notsogood'],
             final=True
         )
 
     def test_final_comment(self):
         self.lex_it(
-            b'hello%',
-            b'h|e|l|l|o'.split(b'|'),
+            u'hello%',
+            u'h|e|l|l|o'.split(u'|'),
             final=True
         )
 
     def test_hash(self):
-        self.lex_it(b'#', [b'#'], final=True)
+        self.lex_it(u'#', [u'#'], final=True)
 
     def test_tab(self):
-        self.lex_it(b'\\c\tc', b'\\c|c'.split(b'|'), final=True)
+        self.lex_it(u'\\c\tc', u'\\c|c'.split(u'|'), final=True)
 
 
 class UnicodeLatexIncrementalDecoderTest(LatexIncrementalDecoderTest):
@@ -387,8 +383,8 @@ class LatexIncrementalDecoderReplaceTest(BaseLatexIncrementalDecoderTest):
 
     def test_errors_replace(self):
         self.lex_it(
-            b'helmocklo',
-            b'?|?|?|mock|?|?'.split(b'|'),
+            u'helmocklo',
+            u'\ufffd|\ufffd|\ufffd|mock|\ufffd|\ufffd'.split(u'|'),
             final=True
         )
 
@@ -400,8 +396,8 @@ class LatexIncrementalDecoderIgnoreTest(BaseLatexIncrementalDecoderTest):
 
     def test_errors_ignore(self):
         self.lex_it(
-            b'helmocklo',
-            b'mock'.split(b'|'),
+            u'helmocklo',
+            u'mock'.split(u'|'),
             final=True
         )
 
@@ -414,8 +410,8 @@ class LatexIncrementalDecoderInvalidErrorTest(BaseLatexIncrementalDecoderTest):
     @nose.tools.raises(NotImplementedError)
     def test_errors_invalid(self):
         self.lex_it(
-            b'helmocklo',
-            b'?|?|?|mock|?|?'.split(b'|'),
+            u'helmocklo',
+            u'?|?|?|mock|?|?'.split(u'|'),
             final=True
         )
 
@@ -459,12 +455,12 @@ class LatexIncrementalLexerTest(TestCase):
 
     def test_newline(self):
         self.lex_it(
-            b"hello\nworld", b"h|e|l|l|o| |w|o|r|l|d".split(b'|'),
+            u"hello\nworld", u"h|e|l|l|o| |w|o|r|l|d".split(u'|'),
             final=True)
 
     def test_par(self):
         self.lex_it(
-            b"hello\n\nworld", b"h|e|l|l|o| |\\par|w|o|r|l|d".split(b'|'),
+            u"hello\n\nworld", u"h|e|l|l|o| |\\par|w|o|r|l|d".split(u'|'),
             final=True)
 
 


### PR DESCRIPTION
and is run after LaTeX is decoded from its own encoding. This should give better handling of LaTeX encodings other than ascii or utf8. (A test case was added for GB2312.)

Please note that I had to change a lot of test cases in `test_latex_lexer.py`.

Fixes issue #62 more thoroughly.
