### PR TITLE
Issue #75: Update find_latex() for Python 3.9

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@
 
 * Minor fix in decoding of LaTeX comments (see issue #72).
 
+* Support Python 3.9 (see issue #75).
+
 1.0.7 (3 May 2019)
 ------------------
 

--- a/latexcodec/codec.py
+++ b/latexcodec/codec.py
@@ -868,7 +868,12 @@ def find_latex(encoding):
     or to ``latex+<encoding>``
     where ``<encoding>`` describes another encoding.
     """
-    encoding, _, inputenc_ = encoding.partition(u"+")
+    if u'_' in encoding:
+        # Python 3.9 now normalizes "latex+latin1" to "latex_latin1"
+        # https://bugs.python.org/issue37751
+        encoding, _, inputenc_ = encoding.partition(u"_")
+    else:
+        encoding, _, inputenc_ = encoding.partition(u"+")
     if not inputenc_:
         inputenc_ = "ascii"
     if encoding == "latex":


### PR DESCRIPTION
Python 3.9 now normalizes "latex+latin1" to "latex_latin1":
https://bugs.python.org/issue37751

find_latex() now splits the encoding name on "_" if it contains "_",
or split on "+" otherwise.