### PR TITLE
 Adding Power support(ppc64le) with ci and testing to the project for architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 dist: focal
+arch:
+    - amd64
+    - ppc64le
 matrix:
   include:
     - python: "3.9-dev"
@@ -7,6 +10,12 @@ matrix:
     - python: "3.7"
     - python: "3.6"
     - python: "pypy3"
+    - python: "3.9-dev"
+      arch: ppc64le
+    - python: "3.8"
+      arch: ppc64le
+    - python: "3.6"
+      arch: ppc64le
 branches:
   only:
     - develop


### PR DESCRIPTION
I am part of IBM team and working on porting power arch to packages as continuous integration & testing.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly,
we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.

Please verify and merge
